### PR TITLE
Add more verbose logs for better insights

### DIFF
--- a/src/chia_log/handlers/finished_signage_point_handler.py
+++ b/src/chia_log/handlers/finished_signage_point_handler.py
@@ -55,6 +55,7 @@ class NonSkippedSignagePoints(ConditionChecker):
     """
 
     def __init__(self):
+        logging.info("Enabled check for finished signage points.")
         self._last_processed_signage_point = None
         self._roll_over_point = 64
 

--- a/src/chia_log/handlers/harvester_activity_handler.py
+++ b/src/chia_log/handlers/harvester_activity_handler.py
@@ -72,6 +72,7 @@ class TimeSinceLastFarmEvent(HarvesterConditionChecker):
     """
 
     def __init__(self):
+        logging.info("Enabled check for farming events.")
         self._warning_threshold = 60
         self._last_timestamp = None
 
@@ -104,6 +105,7 @@ class NonDecreasingPlots(HarvesterConditionChecker):
     """
 
     def __init__(self):
+        logging.info("Enabled check for non-decreasing total plot count.")
         self._max_farmed_plots = 0
 
     def check(self, obj: HarvesterActivityMessage) -> Optional[Event]:
@@ -132,6 +134,7 @@ class QuickPlotSearchTime(HarvesterConditionChecker):
     """
 
     def __init__(self):
+        logging.info("Enabled check for time taken to respond to challenges.")
         self._warning_threshold = 25  # seconds
 
     def check(self, obj: HarvesterActivityMessage) -> Optional[Event]:
@@ -147,6 +150,9 @@ class QuickPlotSearchTime(HarvesterConditionChecker):
 
 class FoundProofs(HarvesterConditionChecker):
     """Check if any proofs were found."""
+
+    def __init__(self):
+        logging.info("Enabled check for found proofs.")
 
     def check(self, obj: HarvesterActivityMessage) -> Optional[Event]:
         if obj.found_proofs_count > 0:

--- a/src/chia_log/log_consumer.py
+++ b/src/chia_log/log_consumer.py
@@ -46,6 +46,7 @@ class FileLogConsumer(LogConsumer):
     """Specific implementation for a simple file consumer"""
 
     def __init__(self, log_path: Path):
+        logging.info("Enabled file log parser.")
         super().__init__()
         self._log_path = log_path
         self._is_running = True

--- a/src/chia_log/parsers/finished_signage_point_parser.py
+++ b/src/chia_log/parsers/finished_signage_point_parser.py
@@ -1,5 +1,6 @@
 # std
 import re
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import List
@@ -24,6 +25,7 @@ class FinishedSignagePointParser:
     """
 
     def __init__(self):
+        logging.info("Enabled parser for finished signage points.")
         # Doing some "smart" tricks with this expression to also match the 64th signage point
         # with the same regex expression. See test examples to see how they differ.
         self._regex = re.compile(r"([0-9:.]*) full_node src.full_node.full_node : INFO\s* ⏲️  [a-z A-Z,]* ([0-9]*)\/64")

--- a/src/chia_log/parsers/harvester_activity_parser.py
+++ b/src/chia_log/parsers/harvester_activity_parser.py
@@ -1,5 +1,6 @@
 # std
 import re
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import List
@@ -28,6 +29,7 @@ class HarvesterActivityParser:
     """
 
     def __init__(self):
+        logging.info("Enabled parser for harvester activity - eligible plot events.")
         self._regex = re.compile(
             r"([0-9:.]*) harvester src.harvester.harvester : INFO\s*([0-9]) plots were "
             r"eligible for farming ([0-9a-z.]*) Found ([0-9]) proofs. Time: ([0-9.]*) s. "

--- a/src/notifier/keep_alive_monitor.py
+++ b/src/notifier/keep_alive_monitor.py
@@ -62,6 +62,7 @@ class KeepAliveMonitor:
             events = []
             for service in self._last_keep_alive.keys():
                 seconds_since_last = (datetime.now() - self._last_keep_alive[service]).seconds
+                logging.info(f"Keep-alive check for {service.name}: Last activity {seconds_since_last} seconds ago.")
                 if seconds_since_last > self._last_keep_alive_threshold_seconds[service]:
                     message = (
                         f"No keep-alive events from harvester for the past {seconds_since_last} seconds. "

--- a/src/notifier/notify_manager.py
+++ b/src/notifier/notify_manager.py
@@ -28,9 +28,14 @@ class NotifyManager:
                 logging.warning(f"Cannot find mapping for {key} notifier.")
             if self._config[key]["enable"]:
                 self._notifiers.append(key_notifier_mapping[key](self._config[key]))
+        if len(self._notifiers) == 0:
+            logging.warning("Cannot process user events: 0 notifiers are enabled!")
 
     def process_events(self, events: List[Event]):
         """Process all keep-alive and user events"""
+        if not len(events):
+            return
+
         self._keep_alive_monitor.process_events(events)
         for notifier in self._notifiers:
             notifier.send_events_to_user(events)


### PR DESCRIPTION
Logs indicating what checks and services are active to help provide
confidence that everything is running.

Also add warning log in case no notification service was enabled in the
config and info log for every keep-alive check.