### PR TITLE
add 'pip3 install wheel' to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ python3 -m venv venv
 3. Install the dependencies:
 
 ```
-pip3 install -r requirements.txt
+pip3 install wheel && pip3 install -r requirements.txt
 ```
 
 4. Copy the example config file


### PR DESCRIPTION
idk if this is the right way to approach or document this but I tried `pip3 install -r requirements.txt` on my chia farming rig (Ubuntu 20.04 LTS) and got the error

```
  Building wheel for PyYAML (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/user/chiadog/venv/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-ey_gycdo/PyYAML/setup.py'"'"'; __file__='"'"'/tmp/pip-install-ey_gycdo/PyYAML/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-gruzyp5r
       cwd: /tmp/pip-install-ey_gycdo/PyYAML/
  Complete output (6 lines):
  usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: setup.py --help [cmd1 cmd2 ...]
     or: setup.py --help-commands
     or: setup.py cmd --help
  
  error: invalid command 'bdist_wheel'
  ----------------------------------------
  ERROR: Failed building wheel for PyYAML
``` 

`pip3 install wheel` fixed it for me

Thanks for sharing this library!