### PR TITLE
Fix SMTP issue by always getting a new connection

### DIFF
--- a/src/notifier/smtp_notifier.py
+++ b/src/notifier/smtp_notifier.py
@@ -27,26 +27,6 @@ class SMTPNotifier(Notifier):
         except KeyError as key:
             logging.error(f"Invalid config.yaml. Missing key: {key}")
 
-        self._smtp = None
-
-    def get_smtp_server(self):
-        # Reuse the existing SMTP connection if it is available
-        if self._smtp and self._smtp.noop()[0]:
-            return self._smtp
-        if self._smtp:
-            self._smtp.quit()
-        self._smtp = smtplib.SMTP(self.host, self.port)
-        self._smtp.ehlo()
-        self._smtp.starttls()
-        # stmplib docs recommend calling ehlo() before & after starttls()
-        self._smtp.ehlo()
-        self._smtp.login(self.username_smtp, self.password_smtp)
-        return self._smtp
-
-    def __del__(self):
-        if self._smtp:
-            self._smtp.quit()
-
     def send_events_to_user(self, events: List[Event]) -> bool:
         errors = False
         for event in events:
@@ -77,8 +57,14 @@ class SMTPNotifier(Notifier):
 
                 # Try to send the message.
                 try:
-                    server = self.get_smtp_server()
+                    server = smtplib.SMTP(self.host, self.port)
+                    server.ehlo()
+                    server.starttls()
+                    # stmplib docs recommend calling ehlo() before & after starttls()
+                    server.ehlo()
+                    server.login(self.username_smtp, self.password_smtp)
                     server.sendmail(self.sender, self.recipient, msg.as_string())
+                    server.quit()
                 # Display an error message if something goes wrong.
                 except Exception as e:
                     logging.error("SMTP Notify Error: ", e)


### PR DESCRIPTION
The open SMTP connection would sometimes return a positive response to noop's but throw an error when trying to send an email. Reverting back to creating a new connection each time until someone finds a better way to persist the connection.