### PR TITLE
Measure time it takes to send notifications and reduce boilerplate code in tests

### DIFF
--- a/src/notifier/notify_manager.py
+++ b/src/notifier/notify_manager.py
@@ -1,5 +1,6 @@
 # std
 import logging
+import time
 from typing import List
 
 # project
@@ -23,7 +24,7 @@ class NotifyManager:
     def __init__(self, config: Config, keep_alive_monitor: KeepAliveMonitor = None):
         self._keep_alive_monitor = keep_alive_monitor or KeepAliveMonitor()
         self._keep_alive_monitor.set_notify_manager(self)
-        self._notifiers: List[Notifier] = []
+        self._notifiers: dict[str, Notifier] = {}
         self._config = config.get_notifier_config()
         self._notification_title_prefix = config.get_config()["notification_title_prefix"]
         self._initialize_notifiers()
@@ -41,10 +42,11 @@ class NotifyManager:
             if key not in key_notifier_mapping.keys():
                 logging.warning(f"Cannot find mapping for {key} notifier.")
             if self._config[key]["enable"]:
-                self._notifiers.append(
-                    key_notifier_mapping[key](title_prefix=self._notification_title_prefix, config=self._config[key])
+                self._notifiers[key] = key_notifier_mapping[key](
+                    title_prefix=self._notification_title_prefix, config=self._config[key]
                 )
-        if len(self._notifiers) == 0:
+
+        if len(self._notifiers.values()) == 0:
             logging.warning("Cannot process user events: 0 notifiers are enabled!")
 
     def process_events(self, events: List[Event]):
@@ -53,5 +55,11 @@ class NotifyManager:
             return
 
         self._keep_alive_monitor.process_events(events)
-        for notifier in self._notifiers:
-            notifier.send_events_to_user(events)
+        for key in self._notifiers.keys():
+            start = time.perf_counter()
+            errors = self._notifiers[key].send_events_to_user(events)
+            execution_time_seconds = time.perf_counter() - start
+            if execution_time_seconds > 5:
+                logging.info(f"Sending events over {key} took {execution_time_seconds:0.2f} seconds.")
+            if errors:
+                logging.warning(f"Encountered errors trying to send events over {key}")

--- a/tests/notifier/dummy_events.py
+++ b/tests/notifier/dummy_events.py
@@ -1,0 +1,43 @@
+# project
+from src.notifier import Event, EventType, EventPriority, EventService
+
+
+class DummyEvents:
+    @staticmethod
+    def get_low_priority_events():
+        return [
+            Event(
+                type=EventType.USER,
+                priority=EventPriority.LOW,
+                service=EventService.HARVESTER,
+                message="Low priority notification 1.",
+            ),
+            Event(
+                type=EventType.USER,
+                priority=EventPriority.LOW,
+                service=EventService.HARVESTER,
+                message="Low priority notification 2.",
+            ),
+        ]
+
+    @staticmethod
+    def get_normal_priority_events():
+        return [
+            Event(
+                type=EventType.USER,
+                priority=EventPriority.NORMAL,
+                service=EventService.HARVESTER,
+                message="Normal priority notification 1.",
+            ),
+        ]
+
+    @staticmethod
+    def get_high_priority_events():
+        return [
+            Event(
+                type=EventType.USER,
+                priority=EventPriority.HIGH,
+                service=EventService.HARVESTER,
+                message="High priority notification 1.",
+            ),
+        ]

--- a/tests/notifier/test_discord_notifier.py
+++ b/tests/notifier/test_discord_notifier.py
@@ -3,8 +3,8 @@ import os
 import unittest
 
 # project
-from src.notifier import Event, EventType, EventPriority, EventService
 from src.notifier.discord_notifier import DiscordNotifier
+from .dummy_events import DummyEvents
 
 
 class TestDiscordNotifier(unittest.TestCase):
@@ -15,60 +15,15 @@ class TestDiscordNotifier(unittest.TestCase):
 
     @unittest.skipUnless(os.getenv("DISCORD_WEBHOOK_URL"), "Run only if webhook available")
     def testDiscordLowPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.LOW,
-                    service=EventService.HARVESTER,
-                    message="Low priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.LOW,
-                    service=EventService.HARVESTER,
-                    message="Low priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_low_priority_events())
         self.assertFalse(errors)
 
     @unittest.skipUnless(os.getenv("DISCORD_WEBHOOK_URL"), "Run only if webhook available")
     def testDiscordNormalPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.NORMAL,
-                    service=EventService.HARVESTER,
-                    message="Normal priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.NORMAL,
-                    service=EventService.HARVESTER,
-                    message="Normal priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_normal_priority_events())
         self.assertFalse(errors)
 
     @unittest.skipUnless(os.getenv("DISCORD_WEBHOOK_URL"), "Run only if webhook available")
     def testDiscordHighPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.HIGH,
-                    service=EventService.HARVESTER,
-                    message="High priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.HIGH,
-                    service=EventService.HARVESTER,
-                    message="High priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_high_priority_events())
         self.assertFalse(errors)

--- a/tests/notifier/test_discord_notifier.py
+++ b/tests/notifier/test_discord_notifier.py
@@ -11,9 +11,7 @@ class TestDiscordNotifier(unittest.TestCase):
     def setUp(self) -> None:
         webhook_url = os.getenv("DISCORD_WEBHOOK_URL")
         self.assertIsNotNone(webhook_url, "You must export DISCORD_WEBHOOK_URL as env variable")
-        self.notifier = DiscordNotifier(
-            title_prefix="Test", config={"enable": True, "webhook_url": webhook_url}
-        )
+        self.notifier = DiscordNotifier(title_prefix="Test", config={"enable": True, "webhook_url": webhook_url})
 
     @unittest.skipUnless(os.getenv("DISCORD_WEBHOOK_URL"), "Run only if webhook available")
     def testDiscordLowPriorityNotifications(self):

--- a/tests/notifier/test_pushover_notifier.py
+++ b/tests/notifier/test_pushover_notifier.py
@@ -5,6 +5,7 @@ import unittest
 # project
 from src.notifier import Event, EventType, EventPriority, EventService
 from src.notifier.pushover_notifier import PushoverNotifier
+from .dummy_events import DummyEvents
 
 
 class TestPushoverNotifier(unittest.TestCase):
@@ -19,50 +20,17 @@ class TestPushoverNotifier(unittest.TestCase):
 
     @unittest.skipUnless(os.getenv("PUSHOVER_API_TOKEN"), "Run only if token available")
     def testLowPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.LOW,
-                    service=EventService.HARVESTER,
-                    message="Low priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.LOW,
-                    service=EventService.HARVESTER,
-                    message="Low priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_low_priority_events())
         self.assertFalse(errors)
 
     @unittest.skipUnless(os.getenv("PUSHOVER_API_TOKEN"), "Run only if token available")
     def testNormalPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.NORMAL,
-                    service=EventService.HARVESTER,
-                    message="Normal priority notification.",
-                )
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_normal_priority_events())
         self.assertFalse(errors)
 
     @unittest.skipUnless(os.getenv("PUSHOVER_API_TOKEN"), "Run only if token available")
     def testHighPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.HIGH,
-                    service=EventService.HARVESTER,
-                    message="This is a high priority notification!",
-                )
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_high_priority_events())
         self.assertFalse(errors)
 
     @unittest.skipUnless(os.getenv("SHOWCASE_NOTIFICATIONS"), "Only for showcasing")

--- a/tests/notifier/test_script_notifier.py
+++ b/tests/notifier/test_script_notifier.py
@@ -2,8 +2,8 @@
 import unittest
 
 # project
-from src.notifier import Event, EventType, EventPriority, EventService
 from src.notifier.script_notifier import ScriptNotifier
+from .dummy_events import DummyEvents
 
 
 class TestScriptNotifier(unittest.TestCase):
@@ -13,46 +13,13 @@ class TestScriptNotifier(unittest.TestCase):
         )
 
     def testLowPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.LOW,
-                    service=EventService.HARVESTER,
-                    message="Low priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.LOW,
-                    service=EventService.HARVESTER,
-                    message="Low priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_low_priority_events())
         self.assertFalse(errors)
 
     def testNormalPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.NORMAL,
-                    service=EventService.HARVESTER,
-                    message="Normal priority notification.",
-                )
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_normal_priority_events())
         self.assertFalse(errors)
 
     def testHighPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.HIGH,
-                    service=EventService.HARVESTER,
-                    message="This is a high priority notification!",
-                )
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_high_priority_events())
         self.assertFalse(errors)

--- a/tests/notifier/test_slack_notifier.py
+++ b/tests/notifier/test_slack_notifier.py
@@ -3,8 +3,8 @@ import os
 import unittest
 
 # project
-from src.notifier import Event, EventType, EventPriority, EventService
 from src.notifier.slack_notifier import SlackNotifier
+from .dummy_events import DummyEvents
 
 
 class TestSlackNotifier(unittest.TestCase):
@@ -15,60 +15,15 @@ class TestSlackNotifier(unittest.TestCase):
 
     @unittest.skipUnless(os.getenv("SLACK_WEBHOOK_URL"), "Run only if webhook available")
     def testSlackLowPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.LOW,
-                    service=EventService.HARVESTER,
-                    message="Low priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.LOW,
-                    service=EventService.HARVESTER,
-                    message="Low priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_low_priority_events())
         self.assertFalse(errors)
 
     @unittest.skipUnless(os.getenv("SLACK_WEBHOOK_URL"), "Run only if webhook available")
     def testSlackNormalPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.NORMAL,
-                    service=EventService.HARVESTER,
-                    message="Normal priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.NORMAL,
-                    service=EventService.HARVESTER,
-                    message="Normal priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_normal_priority_events())
         self.assertFalse(errors)
 
     @unittest.skipUnless(os.getenv("SLACK_WEBHOOK_URL"), "Run only if webhook available")
     def testSlackHighPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.HIGH,
-                    service=EventService.HARVESTER,
-                    message="High priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.HIGH,
-                    service=EventService.HARVESTER,
-                    message="High priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_high_priority_events())
         self.assertFalse(errors)

--- a/tests/notifier/test_smtp_notifier.py
+++ b/tests/notifier/test_smtp_notifier.py
@@ -3,8 +3,8 @@ import os
 import unittest
 
 # project
-from src.notifier import Event, EventType, EventPriority, EventService
 from src.notifier.smtp_notifier import SMTPNotifier
+from .dummy_events import DummyEvents
 
 
 class TestSMTPNotifier(unittest.TestCase):
@@ -40,60 +40,15 @@ class TestSMTPNotifier(unittest.TestCase):
 
     @unittest.skipUnless(os.getenv("USERNAME_SMTP"), "Run only if SMTP available")
     def testSTMPLowPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.LOW,
-                    service=EventService.HARVESTER,
-                    message="Low priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.LOW,
-                    service=EventService.HARVESTER,
-                    message="Low priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_low_priority_events())
         self.assertFalse(errors)
 
     @unittest.skipUnless(os.getenv("USERNAME_SMTP"), "Run only if SMTP available")
     def testSMTPNormalPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.NORMAL,
-                    service=EventService.HARVESTER,
-                    message="Normal priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.NORMAL,
-                    service=EventService.HARVESTER,
-                    message="Normal priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_normal_priority_events())
         self.assertFalse(errors)
 
     @unittest.skipUnless(os.getenv("USERNAME_SMTP"), "Run only if SMTP available")
     def testSTMPHighPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.HIGH,
-                    service=EventService.HARVESTER,
-                    message="High priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.HIGH,
-                    service=EventService.HARVESTER,
-                    message="High priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_high_priority_events())
         self.assertFalse(errors)

--- a/tests/notifier/test_telegram_notifier.py
+++ b/tests/notifier/test_telegram_notifier.py
@@ -3,8 +3,8 @@ import os
 import unittest
 
 # project
-from src.notifier import Event, EventType, EventPriority, EventService
 from src.notifier.telegram_notifier import TelegramNotifier
+from .dummy_events import DummyEvents
 
 
 class TestTelegramNotifier(unittest.TestCase):
@@ -19,60 +19,15 @@ class TestTelegramNotifier(unittest.TestCase):
 
     @unittest.skipUnless(os.getenv("TELEGRAM_BOT_TOKEN"), "Run only if token available")
     def testTelegramLowPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.LOW,
-                    service=EventService.HARVESTER,
-                    message="Low priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.LOW,
-                    service=EventService.HARVESTER,
-                    message="Low priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_low_priority_events())
         self.assertFalse(errors)
 
     @unittest.skipUnless(os.getenv("TELEGRAM_BOT_TOKEN"), "Run only if token available")
     def testTelegramNormalPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.NORMAL,
-                    service=EventService.HARVESTER,
-                    message="Normal priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.NORMAL,
-                    service=EventService.HARVESTER,
-                    message="Normal priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_normal_priority_events())
         self.assertFalse(errors)
 
     @unittest.skipUnless(os.getenv("TELEGRAM_BOT_TOKEN"), "Run only if token available")
     def testTelegramHighPriorityNotifications(self):
-        errors = self.notifier.send_events_to_user(
-            events=[
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.HIGH,
-                    service=EventService.HARVESTER,
-                    message="High priority notification 1.",
-                ),
-                Event(
-                    type=EventType.USER,
-                    priority=EventPriority.HIGH,
-                    service=EventService.HARVESTER,
-                    message="High priority notification 2.",
-                ),
-            ]
-        )
+        errors = self.notifier.send_events_to_user(events=DummyEvents.get_high_priority_events())
         self.assertFalse(errors)


### PR DESCRIPTION
Measure time on notifiers to be aware of any requests taking too long. Subsequent PR will also add explicit timeouts for the connections and better error handling.