### PR TITLE
Fix #46 - division by zero

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is and how it can be reproduced.
+
+**Environment:**
+ - OS: 
+ - Python version:
+ - PIP version:
+ - Chia version:

--- a/.github/ISSUE_TEMPLATE/idea---suggestion---question---discussion.md
+++ b/.github/ISSUE_TEMPLATE/idea---suggestion---question---discussion.md
@@ -1,0 +1,12 @@
+---
+name: Idea / Suggestion / Question / Discussion
+about: You have some idea or feature suggestion?
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Please describe any concrete suggestions for improvement here.
+
+If you have a question or general discussion topic, please [start a new discussion](https://github.com/martomi/chiadog/discussions) instead.

--- a/src/chia_log/handlers/daily_stats/stat_accumulators/signage_point_stats.py
+++ b/src/chia_log/handlers/daily_stats/stat_accumulators/signage_point_stats.py
@@ -34,7 +34,9 @@ class SignagePointStats(FinishedSignageConsumer, StatAccumulator):
         self._last_signage_point = obj.signage_point
 
     def get_summary(self) -> str:
-        percentage_skipped = (self._skips_total / self._total) * 100
+        percentage_skipped = 0
+        if self._total > 0:
+            percentage_skipped = (self._skips_total / self._total) * 100
         if self._skips_total > 0:
             return f"Skipped SPs ⚠️: {self._skips_total} ({percentage_skipped:0.2f}%)"
         return "Skipped SPs ✅️: None"


### PR DESCRIPTION
Fix divisionByZero error if self._total=0 e.g. on harvester-only machines by setting percentage_skipped zero by default and only calculating the percentage if self._total is greater than zero.