### PR TITLE
Improve cross-platform implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # secrets
 config.yaml
+config.*.yaml
 
 # dev files
 .idea

--- a/src/chia_log/log_consumer.py
+++ b/src/chia_log/log_consumer.py
@@ -12,15 +12,14 @@ import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path, PurePosixPath, PureWindowsPath, PurePath
 from threading import Thread
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 # project
 from src.config import check_keys, is_win_platform
+from src.util import OS
 
 # lib
 import paramiko
-
-from src.util import OS
 
 
 class LogConsumerSubscriber(ABC):
@@ -83,7 +82,7 @@ class FileLogConsumer(LogConsumer):
 class NetworkLogConsumer(LogConsumer):
     """Consume logs over the network"""
 
-    def __init__(self, remote_log_path: PurePath, remote_user, remote_host, remote_platform=OS.LINUX):
+    def __init__(self, remote_log_path: PurePath, remote_user: str, remote_host: str, remote_platform: OS):
         logging.info("Enabled network log consumer.")
         super().__init__()
 
@@ -122,7 +121,7 @@ class NetworkLogConsumer(LogConsumer):
             self._notify_subscribers(log_line)
 
 
-def get_host_info(host: str, user: str, path: str):
+def get_host_info(host: str, user: str, path: str) -> Tuple[OS, PurePath]:
 
     client = paramiko.client.SSHClient()
     client.load_system_host_keys()
@@ -141,7 +140,7 @@ def get_host_info(host: str, user: str, path: str):
     else:
         logging.error("Found unsupported platform on remote host, assuming Linux and hope for the best.")
 
-    return OS.LINUX
+    return OS.LINUX, PurePosixPath(path)
 
 
 def create_log_consumer_from_config(config: dict) -> Optional[LogConsumer]:

--- a/src/util.py
+++ b/src/util.py
@@ -3,7 +3,6 @@ from enum import Enum
 
 class OS(Enum):
 
-    LINUX = 'LINUX'
-    MACOS = 'MACOS'
-    WINDOWS = 'WINDOWS'
-
+    LINUX = "LINUX"
+    MACOS = "MACOS"
+    WINDOWS = "WINDOWS"


### PR DESCRIPTION
Made the following changes to fix a Pathlib bug where the log file could not be found in the event of a Windows-run chiadog connecting to a remote Linux harvester:

- Renamed `_get_remote_platform()` to `get_host_info()` and made it static.

- Moved `get_host_info()` from class initializer to `create_log_consumer_from_config()`

- Replaced `Path` with either `PosixPurePath` or `WindowsPurePath` depending on  remote host OS info

- Added line to `.gitignore` to allow multi-remote testing

Also some minor updates `util.py` and log_consumer.py based on code formatter output