### PR TITLE
Add MQTT Notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.1] - 2021-04-27
+
+### Added
+
+- Daily report for number of occasions where plot seeking time is above 5 and 15 seconds.
+  See [this issue](https://github.com/martomi/chiadog/issues/49) to understand why you really want response time < 5
+  seconds and not 30 seconds. You're going to get a notification for anything over 20 seconds which is in the critical
+  range.
+- Windows: Experimental support (thanks [@skrustev](https://github.com/skrustev)) - not yet a one-click easy setup - it
+  may require some tinkering. If you are comfortable with the shell, please try it out and provide us feedback.
+- Windows: Support for remote harvesters on Windows machines (thanks [@pieterhelsen](https://github.com/pieterhelsen))
+
+### Fixed
+
+- [ZeroDivisionError](https://github.com/martomi/chiadog/issues/46) on the daily report. Occurs when running `chiadog`
+  on a standalone harvester where logs about signage points are not present. Now this case is handled correctly.
+
 ## [0.4.0] - 2021-04-25
 
 > This release contains backward incompatible changes to the config.yaml. Please transfer your API keys to a new copy of the config-example.yaml file when updating.
@@ -81,7 +98,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Adds basic condition checks for harvester operations.
 - Adds integration for Pushover (mobile notifications).
 
-[Unreleased]: https://github.com/martomi/chiadog/compare/v0.4.0...dev
+[Unreleased]: https://github.com/martomi/chiadog/compare/v0.4.1...dev
+
+[0.4.1]: https://github.com/martomi/chiadog/releases/tag/v0.4.1
 
 [0.4.0]: https://github.com/martomi/chiadog/releases/tag/v0.4.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,19 @@ black src tests && mypy src tests && flake8 src tests
 
 3. Run tests:
 
+Linux/MacOS:
+
 ```
 PUSHOVER_API_TOKEN=<your_token> PUSHOVER_USER_KEY=<your_key> TELEGRAM_BOT_TOKEN=<your_token> TELEGRAM_CHAT_ID=<your_chat_id>  python3 -m unittest
+```
+
+Windows (from cmdline):
+
+```
+set PUSHOVER_API_TOKEN=<your_token>
+set PUSHOVER_USER_KEY=<your_key> 
+set TELEGRAM_BOT_TOKEN=<your_token> 
+set TELEGRAM_CHAT_ID=<your_chat_id>
 ```
 
 Check that all passes and there aren't any warnings.

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -73,3 +73,14 @@ notifier:
     daily_stats: true
     credentials:
       webhook_url: 'https://hooks.slack.com/services/...'
+  mqtt:
+    enable: false
+    daily_stats: true
+    topic: chia/chiadog/alert
+    qos: 1
+    retain: false
+    credentials:
+      host: '192.168.0.10'
+      port: 8883
+      username: ''
+      password: ''

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -76,6 +76,7 @@ notifier:
   mqtt:
     enable: false
     daily_stats: true
+    wallet_events: true
     topic: chia/chiadog/alert
     qos: 1
     retain: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 paramiko==2.7.2
 python-dateutil~=2.8.1
 PyYAML==5.4
+paho-mqtt==1.5.1

--- a/src/chia_log/handlers/daily_stats/stat_accumulators/found_proof_stats.py
+++ b/src/chia_log/handlers/daily_stats/stat_accumulators/found_proof_stats.py
@@ -1,4 +1,5 @@
 # std
+import logging
 from datetime import datetime
 
 # project
@@ -15,6 +16,8 @@ class FoundProofStats(HarvesterActivityConsumer, StatAccumulator):
         self._found_proofs_total = 0
 
     def consume(self, obj: HarvesterActivityMessage):
+        if obj.found_proofs_count > 0:
+            logging.info("Found a proof!")
         self._found_proofs_total += obj.found_proofs_count
 
     def get_summary(self) -> str:

--- a/src/notifier/mqtt_notifier.py
+++ b/src/notifier/mqtt_notifier.py
@@ -1,13 +1,16 @@
 # std
+import json
 import logging
 from typing import List
-from paho.mqtt.client import MQTTMessageInfo, Client, MQTT_ERR_SUCCESS, MQTT_ERR_NO_CONN, error_string, connack_string
 
+# project
 from . import Notifier, Event
+
+# lib
+from paho.mqtt.client import MQTTMessageInfo, Client, MQTT_ERR_SUCCESS, MQTT_ERR_NO_CONN, error_string, connack_string
 
 
 class MqttNotifier(Notifier):
-
     def __init__(self, title_prefix: str, config: dict):
         logging.info("Initializing MQTT notifier.")
         super().__init__(title_prefix, config)
@@ -29,13 +32,13 @@ class MqttNotifier(Notifier):
     def _set_config(self, config: dict):
 
         self._topic = config["topic"]
-        self._qos = config["qos"] if "qos" in config else 0
-        self._retain = config["retain"] if "retain" in config else False
+        self._qos: int = config["qos"] if "qos" in config else 0
+        self._retain: bool = config["retain"] if "retain" in config else False
 
     def _set_credentials(self, credentials: dict):
 
         self._host = credentials["host"]
-        self._port = credentials["port"]
+        self._port: int = credentials["port"]
 
         if "username" in credentials and credentials["username"] != "":
             self._username = credentials["username"]
@@ -64,7 +67,7 @@ class MqttNotifier(Notifier):
 
     def _on_disconnect(self, client, userdata, rc):
 
-        logging.warning("Disconnected from MQTT: {}".format(error_string(rc)))
+        logging.warning(f"Disconnected from MQTT: {error_string(rc)}")
         self._client.loop_stop()
 
     def send_events_to_user(self, events: List[Event]) -> bool:
@@ -72,25 +75,19 @@ class MqttNotifier(Notifier):
         for event in events:
             if event.type in self._notification_types and event.service in self._notification_services:
 
-                payload = {
-                    "type": event.type,
-                    "prio": event.priority,
-                    "msg": event.message
-                }
+                payload = json.dumps({"type": event.type.name, "prio": event.priority.name, "msg": event.message})
 
-                response: MQTTMessageInfo = self._client.publish(self._topic,
-                                                                 payload=payload,
-                                                                 qos=self._qos,
-                                                                 retain=self._retain
-                                                                 )
+                response: MQTTMessageInfo = self._client.publish(
+                    self._topic, payload=payload, qos=self._qos, retain=self._retain
+                )
 
                 if response.rc == MQTT_ERR_SUCCESS:
                     pass
                 elif response.rc == MQTT_ERR_NO_CONN:
-                    logging.warning(f"Message delivery failed because the MQTT Client was not connected")
+                    logging.warning("Message delivery failed because the MQTT Client was not connected")
                     errors = True
                 else:
-                    logging.warning(f"MQTT message delivery failed due to an unknown error")
+                    logging.warning("MQTT message delivery failed due to an unknown error")
                     errors = True
 
         return not errors

--- a/src/notifier/mqtt_notifier.py
+++ b/src/notifier/mqtt_notifier.py
@@ -1,7 +1,7 @@
 # std
 import logging
 from typing import List
-from paho.mqtt.client import MQTTMessageInfo, Client, MQTT_ERR_SUCCESS, MQTT_ERR_NO_CONN
+from paho.mqtt.client import MQTTMessageInfo, Client, MQTT_ERR_SUCCESS, MQTT_ERR_NO_CONN, error_string, connack_string
 
 from . import Notifier, Event
 
@@ -11,6 +11,10 @@ class MqttNotifier(Notifier):
     def __init__(self, title_prefix: str, config: dict):
         logging.info("Initializing MQTT notifier.")
         super().__init__(title_prefix, config)
+
+        self._username = None
+        self._password = None
+
         try:
 
             credentials = config["credentials"]
@@ -52,13 +56,15 @@ class MqttNotifier(Notifier):
 
     def _on_connect(self, client, userdata, flags, rc):
         if self._password:
-            logging.info(f"Successfully connected to MQTT host {self._host} with password authentication")
+            logging.info(f"Connecting to MQTT host {self._host} with password authentication")
         else:
-            logging.info(f"Successfully connected to MQTT host {self._host}")
+            logging.info(f"Connecting to MQTT host {self._host}")
+
+        logging.info(f"MQTT Connection Status: {connack_string(rc)}")
 
     def _on_disconnect(self, client, userdata, rc):
 
-        logging.warning("Disconnected from MQTT: {}".format(rc))
+        logging.warning("Disconnected from MQTT: {}".format(error_string(rc)))
         self._client.loop_stop()
 
     def send_events_to_user(self, events: List[Event]) -> bool:

--- a/src/notifier/mqtt_notifier.py
+++ b/src/notifier/mqtt_notifier.py
@@ -33,10 +33,10 @@ class MqttNotifier(Notifier):
         self._host = credentials["host"]
         self._port = credentials["port"]
 
-        if "mqtt_username" in credentials and credentials["mqtt_username"] != "":
-            self._username = credentials["mqtt_username"]
-        if "mqtt_password" in credentials and credentials["mqtt_password"] != "":
-            self._password = credentials["mqtt_password"]
+        if "username" in credentials and credentials["username"] != "":
+            self._username = credentials["username"]
+        if "password" in credentials and credentials["password"] != "":
+            self._password = credentials["password"]
 
     def _init_mqtt(self):
         self._client: Client = Client()

--- a/src/notifier/mqtt_notifier.py
+++ b/src/notifier/mqtt_notifier.py
@@ -25,7 +25,7 @@ class MqttNotifier(Notifier):
     def _set_config(self, config: dict):
 
         self._topic = config["topic"]
-        self._qos = int(config["qos"]) if "qos" in config else 0
+        self._qos = config["qos"] if "qos" in config else 0
         self._retain = config["retain"] if "retain" in config else False
 
     def _set_credentials(self, credentials: dict):
@@ -33,25 +33,28 @@ class MqttNotifier(Notifier):
         self._host = credentials["host"]
         self._port = credentials["port"]
 
-        if "mqtt_username" in credentials:
+        if "mqtt_username" in credentials and credentials["mqtt_username"] != "":
             self._username = credentials["mqtt_username"]
-        if "mqtt_password" in credentials:
+        if "mqtt_password" in credentials and credentials["mqtt_password"] != "":
             self._password = credentials["mqtt_password"]
 
     def _init_mqtt(self):
         self._client: Client = Client()
         self._client.on_connect = self._on_connect
         self._client.on_disconnect = self._on_disconnect
-        self._client.username_pw_set(self._username, self._password)
+
+        if self._username and self._password:
+            self._client.username_pw_set(self._username, self._password)
+
         self._client.connect(self._host, self._port)
         self._client.reconnect_delay_set()
         self._client.loop_start()
 
     def _on_connect(self, client, userdata, flags, rc):
         if self._password:
-            logging.info(f"Connected to MQTT host {self._host} using authentication")
+            logging.info(f"Successfully connected to MQTT host {self._host} with password authentication")
         else:
-            logging.info(f"Connected to MQTT host {self._host}")
+            logging.info(f"Successfully connected to MQTT host {self._host}")
 
     def _on_disconnect(self, client, userdata, rc):
 
@@ -76,7 +79,7 @@ class MqttNotifier(Notifier):
                                                                  )
 
                 if response.rc == MQTT_ERR_SUCCESS:
-                    pass;
+                    pass
                 elif response.rc == MQTT_ERR_NO_CONN:
                     logging.warning(f"Message delivery failed because the MQTT Client was not connected")
                     errors = True

--- a/src/notifier/mqtt_notifier.py
+++ b/src/notifier/mqtt_notifier.py
@@ -1,0 +1,87 @@
+# std
+import logging
+from typing import List
+from paho.mqtt.client import MQTTMessageInfo, Client, MQTT_ERR_SUCCESS, MQTT_ERR_NO_CONN
+
+from . import Notifier, Event
+
+
+class MqttNotifier(Notifier):
+
+    def __init__(self, title_prefix: str, config: dict):
+        logging.info("Initializing MQTT notifier.")
+        super().__init__(title_prefix, config)
+        try:
+
+            credentials = config["credentials"]
+            self._set_config(config)
+            self._set_credentials(credentials)
+
+        except KeyError as key:
+            logging.error(f"Invalid config.yaml. Missing key: {key}")
+
+        self._init_mqtt()
+
+    def _set_config(self, config: dict):
+
+        self._topic = config["topic"]
+        self._qos = int(config["qos"]) if "qos" in config else 0
+        self._retain = config["retain"] if "retain" in config else False
+
+    def _set_credentials(self, credentials: dict):
+
+        self._host = credentials["host"]
+        self._port = credentials["port"]
+
+        if "mqtt_username" in credentials:
+            self._username = credentials["mqtt_username"]
+        if "mqtt_password" in credentials:
+            self._password = credentials["mqtt_password"]
+
+    def _init_mqtt(self):
+        self._client: Client = Client()
+        self._client.on_connect = self._on_connect
+        self._client.on_disconnect = self._on_disconnect
+        self._client.username_pw_set(self._username, self._password)
+        self._client.connect(self._host, self._port)
+        self._client.reconnect_delay_set()
+        self._client.loop_start()
+
+    def _on_connect(self, client, userdata, flags, rc):
+        if self._password:
+            logging.info(f"Connected to MQTT host {self._host} using authentication")
+        else:
+            logging.info(f"Connected to MQTT host {self._host}")
+
+    def _on_disconnect(self, client, userdata, rc):
+
+        logging.warning("Disconnected from MQTT: {}".format(rc))
+        self._client.loop_stop()
+
+    def send_events_to_user(self, events: List[Event]) -> bool:
+        errors = False
+        for event in events:
+            if event.type in self._notification_types and event.service in self._notification_services:
+
+                payload = {
+                    "type": event.type,
+                    "prio": event.priority,
+                    "msg": event.message
+                }
+
+                response: MQTTMessageInfo = self._client.publish(self._topic,
+                                                                 payload=payload,
+                                                                 qos=self._qos,
+                                                                 retain=self._retain
+                                                                 )
+
+                if response.rc == MQTT_ERR_SUCCESS:
+                    pass;
+                elif response.rc == MQTT_ERR_NO_CONN:
+                    logging.warning(f"Message delivery failed because the MQTT Client was not connected")
+                    errors = True
+                else:
+                    logging.warning(f"MQTT message delivery failed due to an unknown error")
+                    errors = True
+
+        return not errors

--- a/src/notifier/notify_manager.py
+++ b/src/notifier/notify_manager.py
@@ -6,6 +6,7 @@ from typing import List
 # project
 from . import Event, Notifier
 from .keep_alive_monitor import KeepAliveMonitor
+from .mqtt_notifier import MqttNotifier
 from .pushover_notifier import PushoverNotifier
 from .script_notifier import ScriptNotifier
 from .smtp_notifier import SMTPNotifier
@@ -37,6 +38,7 @@ class NotifyManager:
             "discord": DiscordNotifier,
             "smtp": SMTPNotifier,
             "slack": SlackNotifier,
+            "mqtt": MqttNotifier,
         }
         for key in self._config.keys():
             if key not in key_notifier_mapping.keys():

--- a/src/util.py
+++ b/src/util.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class OS(Enum):
+
+    LINUX = 'LINUX'
+    MACOS = 'MACOS'
+    WINDOWS = 'WINDOWS'
+

--- a/tests/chia_log/handlers/test_finished_signage_point_handler.py
+++ b/tests/chia_log/handlers/test_finished_signage_point_handler.py
@@ -13,7 +13,7 @@ class TestFinishedSignagePointHandler(unittest.TestCase):
         self.example_logs_path = Path(__file__).resolve().parents[1] / "logs/finished_signage_point"
 
     def testNominal(self):
-        with open(self.example_logs_path / "nominal.txt") as f:
+        with open(self.example_logs_path / "nominal.txt", encoding="utf-8") as f:
             logs = f.readlines()
 
         # Currently not generating keep-alive events for the full node
@@ -24,7 +24,7 @@ class TestFinishedSignagePointHandler(unittest.TestCase):
             self.assertEqual(len(events), 0, "Not expecting any events")
 
     def testSkippedSignagePoints(self):
-        with open(self.example_logs_path / "skipped.txt") as f:
+        with open(self.example_logs_path / "skipped.txt", encoding="utf-8") as f:
             logs = f.readlines()
 
         expected_messages = [
@@ -51,7 +51,7 @@ class TestFinishedSignagePointHandler(unittest.TestCase):
         It's currently unclear to me why this happens, but it seems to be network-wide issue
         rather than individual node problem. So this test checks that the handler is robust
         to ignoring these events and doesn't generate any false alarms for our node."""
-        with open(self.example_logs_path / "scrambled.txt") as f:
+        with open(self.example_logs_path / "scrambled.txt", encoding="utf-8") as f:
             logs = f.readlines()
 
         for log in logs:

--- a/tests/chia_log/parsers/test_finished_signage_point_parser.py
+++ b/tests/chia_log/parsers/test_finished_signage_point_parser.py
@@ -10,9 +10,9 @@ class TestFinishedSignagePointParser(unittest.TestCase):
     def setUp(self) -> None:
         self.parser = finished_signage_point_parser.FinishedSignagePointParser()
         self.example_logs_path = Path(__file__).resolve().parents[1] / "logs/finished_signage_point"
-        with open(self.example_logs_path / "nominal.txt") as f:
+        with open(self.example_logs_path / "nominal.txt", encoding="utf-8") as f:
             self.nominal_logs = f.read()
-        with open(self.example_logs_path / "nominal_old_log_format.txt") as f:
+        with open(self.example_logs_path / "nominal_old_log_format.txt", encoding="utf-8") as f:
             self.nominal_logs_old_format = f.read()
 
     def tearDown(self) -> None:

--- a/tests/notifier/test_mqtt_notifier.py
+++ b/tests/notifier/test_mqtt_notifier.py
@@ -1,0 +1,64 @@
+# std
+import os
+import unittest
+
+# project
+from src.notifier.mqtt_notifier import MqttNotifier
+from .dummy_events import DummyEvents
+
+
+class TestMqttNotifier(unittest.TestCase):
+    def setUp(self) -> None:
+
+        host = os.getenv("HOST")
+        port = os.getenv("PORT")
+        topic = os.getenv("TOPIC")
+        mqtt_username = os.getenv("MQTT_USERNAME")
+        mqtt_password = os.getenv("MQTT_PASSWORD")
+        qos = os.getenv('QOS')
+        retain = os.getenv('RETAIN')
+
+        self.assertIsNotNone(host, "You must export HOST as env variable")
+        self.assertIsNotNone(port, "You must export PORT as env variable")
+        self.assertIsNotNone(topic, "You must export TOPIC as env variable")
+        self.assertIsNotNone(mqtt_username, "You must export MQTT_USERNAME as env variable")
+        self.assertIsNotNone(mqtt_password, "You must export MQTT_PASSWORD as env variable")
+
+        if retain:
+            self.assertIs(retain, bool, 'Retain must be a boolean value')
+
+        if qos:
+            self.assertIn(qos, [0, 1, 2], "QoS level must be set to 0 (At most once), 1 (at least once) or "
+                                          "2 (Exactly once)")
+
+        self.notifier = MqttNotifier(
+            title_prefix="Test",
+            config={
+                "enable": True,
+                "daily_stats": True,
+                "topic": topic,
+                "qos": qos,
+                "retain": retain,
+                "credentials": {
+                    "host": host,
+                    "port": port,
+                    "mqtt_username": mqtt_username,
+                    "mqtt_password": mqtt_password,
+                },
+            },
+        )
+
+    @unittest.skipUnless(os.getenv("TOPIC"), "Run only if MQTT topic available")
+    def testDiscordLowPriorityNotifications(self):
+        success = self.notifier.send_events_to_user(events=DummyEvents.get_low_priority_events())
+        self.assertTrue(success)
+
+    @unittest.skipUnless(os.getenv("TOPIC"), "Run only if MQTT topic available")
+    def testDiscordNormalPriorityNotifications(self):
+        success = self.notifier.send_events_to_user(events=DummyEvents.get_normal_priority_events())
+        self.assertTrue(success)
+
+    @unittest.skipUnless(os.getenv("TOPIC"), "Run only if MQTT topic available")
+    def testDiscordHighPriorityNotifications(self):
+        success = self.notifier.send_events_to_user(events=DummyEvents.get_high_priority_events())
+        self.assertTrue(success)

--- a/tests/notifier/test_mqtt_notifier.py
+++ b/tests/notifier/test_mqtt_notifier.py
@@ -1,7 +1,6 @@
 # std
 import os
 import unittest
-from typing import Union, SupportsInt
 
 # project
 from src.notifier.mqtt_notifier import MqttNotifier

--- a/tests/notifier/test_mqtt_notifier.py
+++ b/tests/notifier/test_mqtt_notifier.py
@@ -12,20 +12,20 @@ class TestMqttNotifier(unittest.TestCase):
     def setUp(self) -> None:
 
         host = os.getenv("HOST")
-        port = int(os.getenv("PORT"))
         topic = os.getenv("TOPIC")
         username = os.getenv("MQTT_USERNAME")
         password = os.getenv("MQTT_PASSWORD")
-        qos = int(os.getenv("QOS"))
+        port = int(os.getenv("PORT", 1883))
+        qos = int(os.getenv("QOS", 0))
+        retain = bool(os.getenv("RETAIN", False))
 
         self.assertIsNotNone(host, "You must export HOST as env variable")
         self.assertIsNotNone(port, "You must export PORT as env variable")
         self.assertIsNotNone(topic, "You must export TOPIC as env variable")
 
-        if qos:
-            self.assertIn(
-                qos, [0, 1, 2], "QoS level must be set to 0 (At most once), 1 (at least once) or " "2 (Exactly once)"
-            )
+        self.assertIn(
+            qos, [0, 1, 2], "QoS level must be set to 0 (At most once), 1 (at least once) or " "2 (Exactly once)"
+        )
 
         self.notifier = MqttNotifier(
             title_prefix="Test",
@@ -34,6 +34,7 @@ class TestMqttNotifier(unittest.TestCase):
                 "daily_stats": True,
                 "topic": topic,
                 "qos": qos,
+                "retain": retain,
                 "credentials": {
                     "host": host,
                     "port": port,

--- a/tests/notifier/test_mqtt_notifier.py
+++ b/tests/notifier/test_mqtt_notifier.py
@@ -13,16 +13,14 @@ class TestMqttNotifier(unittest.TestCase):
         host = os.getenv("HOST")
         port = os.getenv("PORT")
         topic = os.getenv("TOPIC")
-        mqtt_username = os.getenv("MQTT_USERNAME")
-        mqtt_password = os.getenv("MQTT_PASSWORD")
+        username = os.getenv("MQTT_USERNAME")
+        password = os.getenv("MQTT_PASSWORD")
         qos = os.getenv('QOS')
         retain = os.getenv('RETAIN')
 
         self.assertIsNotNone(host, "You must export HOST as env variable")
         self.assertIsNotNone(port, "You must export PORT as env variable")
         self.assertIsNotNone(topic, "You must export TOPIC as env variable")
-        self.assertIsNotNone(mqtt_username, "You must export MQTT_USERNAME as env variable")
-        self.assertIsNotNone(mqtt_password, "You must export MQTT_PASSWORD as env variable")
 
         if retain:
             self.assertIs(retain, bool, 'Retain must be a boolean value')
@@ -42,8 +40,8 @@ class TestMqttNotifier(unittest.TestCase):
                 "credentials": {
                     "host": host,
                     "port": port,
-                    "mqtt_username": mqtt_username,
-                    "mqtt_password": mqtt_password,
+                    "username": username,
+                    "password": password,
                 },
             },
         )

--- a/tests/notifier/test_mqtt_notifier.py
+++ b/tests/notifier/test_mqtt_notifier.py
@@ -31,6 +31,7 @@ class TestMqttNotifier(unittest.TestCase):
             config={
                 "enable": True,
                 "daily_stats": True,
+                "wallet_events": True,
                 "topic": topic,
                 "qos": qos,
                 "retain": retain,

--- a/tests/notifier/test_mqtt_notifier.py
+++ b/tests/notifier/test_mqtt_notifier.py
@@ -1,6 +1,7 @@
 # std
 import os
 import unittest
+from typing import Union, SupportsInt
 
 # project
 from src.notifier.mqtt_notifier import MqttNotifier
@@ -11,23 +12,20 @@ class TestMqttNotifier(unittest.TestCase):
     def setUp(self) -> None:
 
         host = os.getenv("HOST")
-        port = os.getenv("PORT")
+        port = int(os.getenv("PORT"))
         topic = os.getenv("TOPIC")
         username = os.getenv("MQTT_USERNAME")
         password = os.getenv("MQTT_PASSWORD")
-        qos = os.getenv('QOS')
-        retain = os.getenv('RETAIN')
+        qos = int(os.getenv("QOS"))
 
         self.assertIsNotNone(host, "You must export HOST as env variable")
         self.assertIsNotNone(port, "You must export PORT as env variable")
         self.assertIsNotNone(topic, "You must export TOPIC as env variable")
 
-        if retain:
-            self.assertIs(retain, bool, 'Retain must be a boolean value')
-
         if qos:
-            self.assertIn(qos, [0, 1, 2], "QoS level must be set to 0 (At most once), 1 (at least once) or "
-                                          "2 (Exactly once)")
+            self.assertIn(
+                qos, [0, 1, 2], "QoS level must be set to 0 (At most once), 1 (at least once) or " "2 (Exactly once)"
+            )
 
         self.notifier = MqttNotifier(
             title_prefix="Test",
@@ -36,7 +34,6 @@ class TestMqttNotifier(unittest.TestCase):
                 "daily_stats": True,
                 "topic": topic,
                 "qos": qos,
-                "retain": retain,
                 "credentials": {
                     "host": host,
                     "port": port,
@@ -47,16 +44,16 @@ class TestMqttNotifier(unittest.TestCase):
         )
 
     @unittest.skipUnless(os.getenv("TOPIC"), "Run only if MQTT topic available")
-    def testDiscordLowPriorityNotifications(self):
+    def testMqttLowPriorityNotifications(self):
         success = self.notifier.send_events_to_user(events=DummyEvents.get_low_priority_events())
         self.assertTrue(success)
 
     @unittest.skipUnless(os.getenv("TOPIC"), "Run only if MQTT topic available")
-    def testDiscordNormalPriorityNotifications(self):
+    def testMqttNormalPriorityNotifications(self):
         success = self.notifier.send_events_to_user(events=DummyEvents.get_normal_priority_events())
         self.assertTrue(success)
 
     @unittest.skipUnless(os.getenv("TOPIC"), "Run only if MQTT topic available")
-    def testDiscordHighPriorityNotifications(self):
+    def testMqttHighPriorityNotifications(self):
         success = self.notifier.send_events_to_user(events=DummyEvents.get_high_priority_events())
         self.assertTrue(success)


### PR DESCRIPTION
Added MQTT Notifier and Unit Tests. 
The notifier takes an IP address or hostname, port number and MQTT topic at minimum and supports optional username/password authentication. Retain and QoS parameters can also be passed as config variables.

When called, the notifier will push a message to the provided topic. 
The message will be formatted as:
`{"type": event.type.name, "prio": event.priority.name, "msg": event.message}`

with `type` as:

- USER
- KEEPALIVE
- DAILY_STATS

and `priority` as:

- LOW
- NORMAL
- HIGH