### PR TITLE
Add HTTP stat reporter

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -27,9 +27,10 @@ keep_alive_monitor:
 
 # Enable this and you'll receive a daily summary notification
 # on your farm performance at the specified time of the day.
-daily_stats:
-  enable: true
-  time_of_day: 21
+stats:
+  daily_stats:
+    enable: true
+    time_of_day: 21
 
 # We support a lot of notifiers, please check the README for more
 # information. You can delete the sections which you aren't using.

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -31,6 +31,10 @@ stats:
   daily_stats:
     enable: true
     time_of_day: 21
+  http:
+    enable: true
+    hostname: 'example.com'
+    path: '/some/endpoint'
 
 # We support a lot of notifiers, please check the README for more
 # information. You can delete the sections which you aren't using.

--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     notify_manager = NotifyManager(config=config, keep_alive_monitor=keep_alive_monitor)
 
     # Stats manager accumulates stats over 24 hours and sends a summary each day
-    stats_manager = StatsManager(config=config.get_daily_stats_config(), notify_manager=notify_manager)
+    stats_manager = StatsManager(config=config, notify_manager=notify_manager)
 
     # Link stuff up in the log handler
     # Pipeline: Consume -> Handle -> Notify

--- a/src/chia_log/handlers/daily_stats/__init__.py
+++ b/src/chia_log/handlers/daily_stats/__init__.py
@@ -1,9 +1,24 @@
 # std
 from abc import ABC, abstractmethod
+from typing import List
 
 # project
 from ...parsers.finished_signage_point_parser import FinishedSignagePointMessage
 from ...parsers.harvester_activity_parser import HarvesterActivityMessage
+
+
+class StatReporter(ABC):
+    @abstractmethod
+    def consume_harvester_messages(self, objects: List[HarvesterActivityMessage]):
+        pass
+
+    @abstractmethod
+    def consume_signage_point_messages(self, objects: List[FinishedSignagePointMessage]):
+        pass
+
+    @abstractmethod
+    def report(self):
+        pass
 
 
 class FinishedSignageConsumer(ABC):

--- a/src/chia_log/handlers/daily_stats/__init__.py
+++ b/src/chia_log/handlers/daily_stats/__init__.py
@@ -39,5 +39,9 @@ class StatAccumulator(ABC):
         pass
 
     @abstractmethod
+    def get_data(self) -> dict:
+        pass
+
+    @abstractmethod
     def reset(self):
         pass

--- a/src/chia_log/handlers/daily_stats/stat_accumulators/eligible_plots_stats.py
+++ b/src/chia_log/handlers/daily_stats/stat_accumulators/eligible_plots_stats.py
@@ -24,3 +24,12 @@ class EligiblePlotsStats(HarvesterActivityConsumer, StatAccumulator):
         if self._eligible_events_total == 0:
             return "Eligible plots 🥇: None"
         return f"Eligible plots 🥇: {self._eligible_plots_total / self._eligible_events_total:0.2f} average"
+
+    def get_data(self) -> dict:
+        if self._eligible_events_total == 0:
+            eligible_plots_average = 0
+        else:
+            eligible_plots_average = round(self._eligible_plots_total / self._eligible_events_total, 2)
+        return {
+            'eligible_plots_average': eligible_plots_average
+        }

--- a/src/chia_log/handlers/daily_stats/stat_accumulators/found_proof_stats.py
+++ b/src/chia_log/handlers/daily_stats/stat_accumulators/found_proof_stats.py
@@ -24,3 +24,8 @@ class FoundProofStats(HarvesterActivityConsumer, StatAccumulator):
         if self._found_proofs_total == 0:
             return "Proofs 🧾: None"
         return f"Proofs 🧾: {self._found_proofs_total} found!"
+
+    def get_data(self) -> dict:
+        return {
+            'found_proofs_total': self._found_proofs_total
+        }

--- a/src/chia_log/handlers/daily_stats/stat_accumulators/number_plots_stats.py
+++ b/src/chia_log/handlers/daily_stats/stat_accumulators/number_plots_stats.py
@@ -29,3 +29,8 @@ class NumberPlotsStats(HarvesterActivityConsumer, StatAccumulator):
             return f"Plots 🌱: {self._current_plot_count}, removed: {new_plots}"
 
         return f"Plots 🌱: {self._current_plot_count}"
+
+    def get_data(self) -> dict:
+        return {
+            'current_plot_count': self._current_plot_count
+        }

--- a/src/chia_log/handlers/daily_stats/stat_accumulators/search_time_stats.py
+++ b/src/chia_log/handlers/daily_stats/stat_accumulators/search_time_stats.py
@@ -35,3 +35,10 @@ class SearchTimeStats(HarvesterActivityConsumer, StatAccumulator):
             f"\t - over 5s: {self._over_5_seconds} occasions\n"
             f"\t - over 15s: {self._over_15_seconds} occasions"
         )
+
+    def get_data(self) -> dict:
+        return {
+            'search_time_average': round(self._avg_time_seconds, 2),
+            'search_time_over_5s_count': self._over_5_seconds,
+            'search_time_over_15s_count': self._over_15_seconds
+        }

--- a/src/chia_log/handlers/daily_stats/stat_accumulators/signage_point_stats.py
+++ b/src/chia_log/handlers/daily_stats/stat_accumulators/signage_point_stats.py
@@ -40,3 +40,11 @@ class SignagePointStats(FinishedSignageConsumer, StatAccumulator):
             percentage_skipped = (self._skips_total / self._total) * 100
             return f"Skipped SPs ⚠️: {self._skips_total} ({percentage_skipped:0.2f}%)"
         return "Skipped SPs ✅️: None"
+
+    def get_data(self) -> dict:
+        result = {
+            'signage_point_count': self._total
+        }
+        if self._total > 0:
+            result['skipped_signage_point_count'] = self._skips_total
+        return result

--- a/src/chia_log/handlers/daily_stats/stat_reporters/daily_stats_reporter.py
+++ b/src/chia_log/handlers/daily_stats/stat_reporters/daily_stats_reporter.py
@@ -1,0 +1,82 @@
+# std
+import logging
+from datetime import datetime, timedelta
+from typing import List
+from threading import Thread
+from time import sleep
+
+# project
+from src.chia_log.handlers.daily_stats import HarvesterActivityConsumer, FinishedSignageConsumer, StatReporter
+from src.chia_log.handlers.daily_stats.stat_accumulators.eligible_plots_stats import EligiblePlotsStats
+from src.chia_log.handlers.daily_stats.stat_accumulators.search_time_stats import SearchTimeStats
+from src.chia_log.handlers.daily_stats.stat_accumulators.signage_point_stats import SignagePointStats
+from src.chia_log.handlers.daily_stats.stat_accumulators.found_proof_stats import FoundProofStats
+from src.chia_log.handlers.daily_stats.stat_accumulators.number_plots_stats import NumberPlotsStats
+from src.chia_log.parsers.harvester_activity_parser import HarvesterActivityMessage
+from src.chia_log.parsers.finished_signage_point_parser import FinishedSignagePointMessage
+from src.notifier.notify_manager import NotifyManager
+from src.notifier import Event, EventType, EventPriority, EventService
+
+
+class DailyStatsReporter(StatReporter):
+    """Manage all stat accumulators and trigger daily notification to the user
+    with a summary from all stats that have been collected for the past 24 hours.
+    """
+
+    def __init__(self, config: dict, notify_manager: NotifyManager):
+        try:
+            self._enable = config["enable"]
+            self._time_of_day = config["time_of_day"]
+        except KeyError as key:
+            logging.error(f"Invalid config.yaml. Missing key: {key}")
+            self._enable = False
+
+        if not self._enable:
+            logging.warning("Disabled stats and daily notifications")
+            return
+
+        logging.info("Enabled stats for daily notifications")
+        self._notify_manager = notify_manager
+        self._stat_accumulators = [
+            FoundProofStats(),
+            SearchTimeStats(),
+            NumberPlotsStats(),
+            EligiblePlotsStats(),
+            SignagePointStats(),
+        ]
+
+        logging.info(f"Summary notifications will be sent out daily at {self._time_of_day} o'clock")
+        self._datetime_next_summary = datetime.now().replace(hour=self._time_of_day, minute=0, second=0, microsecond=0)
+        if datetime.now() > self._datetime_next_summary:
+            self._datetime_next_summary += timedelta(days=1)
+
+    def consume_harvester_messages(self, objects: List[HarvesterActivityMessage]):
+        if not self._enable:
+            return
+        for stat_acc in self._stat_accumulators:
+            if isinstance(stat_acc, HarvesterActivityConsumer):
+                for obj in objects:
+                    stat_acc.consume(obj)
+
+    def consume_signage_point_messages(self, objects: List[FinishedSignagePointMessage]):
+        if not self._enable:
+            return
+        for stat_acc in self._stat_accumulators:
+            if isinstance(stat_acc, FinishedSignageConsumer):
+                for obj in objects:
+                    stat_acc.consume(obj)
+
+    def _send_daily_notification(self):
+        summary = "Hello farmer! 👋 Here's what happened in the last 24 hours:\n"
+        for stat_acc in self._stat_accumulators:
+            summary += "\n" + stat_acc.get_summary()
+            stat_acc.reset()
+
+        self._notify_manager.process_events(
+            [Event(type=EventType.DAILY_STATS, priority=EventPriority.LOW, service=EventService.DAILY, message=summary)]
+        )
+
+    def report(self):
+        if datetime.now() > self._datetime_next_summary:
+            self._send_daily_notification()
+            self._datetime_next_summary += timedelta(days=1)

--- a/src/chia_log/handlers/daily_stats/stat_reporters/http_reporter.py
+++ b/src/chia_log/handlers/daily_stats/stat_reporters/http_reporter.py
@@ -1,0 +1,93 @@
+# std
+import http.client
+import json
+import logging
+from datetime import datetime, timedelta
+from typing import List
+
+# project
+from src.chia_log.handlers.daily_stats import StatReporter, HarvesterActivityConsumer, FinishedSignageConsumer
+from src.chia_log.handlers.daily_stats.stat_accumulators.eligible_plots_stats import EligiblePlotsStats
+from src.chia_log.handlers.daily_stats.stat_accumulators.found_proof_stats import FoundProofStats
+from src.chia_log.handlers.daily_stats.stat_accumulators.number_plots_stats import NumberPlotsStats
+from src.chia_log.handlers.daily_stats.stat_accumulators.search_time_stats import SearchTimeStats
+from src.chia_log.handlers.daily_stats.stat_accumulators.signage_point_stats import SignagePointStats
+from src.chia_log.parsers.finished_signage_point_parser import FinishedSignagePointMessage
+from src.chia_log.parsers.harvester_activity_parser import HarvesterActivityMessage
+from src.notifier.notify_manager import NotifyManager
+
+REPORT_INTERVAL_MINUTES = 5
+
+
+class HttpReporter(StatReporter):
+    """Manage all stat accumulators and send regular status reports to a HTTP endpoint.
+    """
+
+    def __init__(self, config: dict, notify_manager: NotifyManager):
+        self._datetime_next_report = datetime.now() + timedelta(minutes=REPORT_INTERVAL_MINUTES)
+
+        try:
+            self._enable = config["enable"]
+            self._hostname = config["hostname"]
+            self._path = config["path"]
+        except KeyError as key:
+            logging.error(f"Invalid config.yaml. Missing key: {key}")
+            self._enable = False
+
+        if not self._enable:
+            logging.warning("Disabled HTTP reporter")
+            return
+
+        logging.info("Enabled HTTP reporter")
+
+        self._stat_accumulators = [
+            FoundProofStats(),
+            SearchTimeStats(),
+            NumberPlotsStats(),
+            EligiblePlotsStats(),
+            SignagePointStats(),
+        ]
+
+    def consume_harvester_messages(self, objects: List[HarvesterActivityMessage]):
+        if not self._enable:
+            return
+        for stat_acc in self._stat_accumulators:
+            if isinstance(stat_acc, HarvesterActivityConsumer):
+                for obj in objects:
+                    stat_acc.consume(obj)
+
+    def consume_signage_point_messages(self, objects: List[FinishedSignagePointMessage]):
+        if not self._enable:
+            return
+        for stat_acc in self._stat_accumulators:
+            if isinstance(stat_acc, FinishedSignageConsumer):
+                for obj in objects:
+                    stat_acc.consume(obj)
+
+    def report(self):
+        if datetime.now() > self._datetime_next_report:
+            request_data = {
+                "timestamp": int(datetime.now().timestamp()),
+            }
+            for stat_acc in self._stat_accumulators:
+                request_data.update(stat_acc.get_data())
+                stat_acc.reset()
+
+            request_body = json.dumps(request_data)
+
+            conn = http.client.HTTPSConnection(self._hostname)
+            conn.request(
+                "POST",
+                self._path,
+                request_body,
+                {"Content-type": "application/json"},
+            )
+            response = conn.getresponse()
+            if response.getcode() != 200:
+                logging.warning(f"Problem reporting to HTTP endpoint, code: {response.getcode()}")
+            else:
+                logging.debug(f'Reported to HTTP endpoint.')
+
+            conn.close()
+
+            self._datetime_next_report += timedelta(minutes=REPORT_INTERVAL_MINUTES)

--- a/src/chia_log/handlers/daily_stats/stats_manager.py
+++ b/src/chia_log/handlers/daily_stats/stats_manager.py
@@ -7,6 +7,7 @@ from typing import List
 # project
 from src.chia_log.handlers.daily_stats import StatReporter
 from src.chia_log.handlers.daily_stats.stat_reporters.daily_stats_reporter import DailyStatsReporter
+from src.chia_log.handlers.daily_stats.stat_reporters.http_reporter import HttpReporter
 from src.chia_log.parsers.finished_signage_point_parser import FinishedSignagePointMessage
 from src.chia_log.parsers.harvester_activity_parser import HarvesterActivityMessage
 from src.config import Config
@@ -25,6 +26,7 @@ class StatsManager:
 
     def _initialize_stats_managers(self):
         key_notifier_mapping = {
+            "http": HttpReporter,
             "daily_stats": DailyStatsReporter
         }
 

--- a/src/chia_log/handlers/daily_stats/stats_manager.py
+++ b/src/chia_log/handlers/daily_stats/stats_manager.py
@@ -1,91 +1,61 @@
 # std
 import logging
-from datetime import datetime, timedelta
-from typing import List
 from threading import Thread
 from time import sleep
+from typing import List
 
 # project
-from . import HarvesterActivityConsumer, FinishedSignageConsumer
-from .stat_accumulators.eligible_plots_stats import EligiblePlotsStats
-from .stat_accumulators.search_time_stats import SearchTimeStats
-from .stat_accumulators.signage_point_stats import SignagePointStats
-from .stat_accumulators.found_proof_stats import FoundProofStats
-from .stat_accumulators.number_plots_stats import NumberPlotsStats
-from src.chia_log.parsers.harvester_activity_parser import HarvesterActivityMessage
+from src.chia_log.handlers.daily_stats import StatReporter
+from src.chia_log.handlers.daily_stats.stat_reporters.daily_stats_reporter import DailyStatsReporter
 from src.chia_log.parsers.finished_signage_point_parser import FinishedSignagePointMessage
+from src.chia_log.parsers.harvester_activity_parser import HarvesterActivityMessage
+from src.config import Config
 from src.notifier.notify_manager import NotifyManager
-from src.notifier import Event, EventType, EventPriority, EventService
 
 
 class StatsManager:
-    """Manage all stat accumulators and trigger daily notification to the user
-    with a summary from all stats that have been collected for the past 24 hours.
+    """Initialize and manage all stat reporters and trigger their reporting.
     """
 
-    def __init__(self, config: dict, notify_manager: NotifyManager):
-        try:
-            self._enable = config["enable"]
-            self._time_of_day = config["time_of_day"]
-        except KeyError as key:
-            logging.error(f"Invalid config.yaml. Missing key: {key}")
-            self._enable = False
-
-        if not self._enable:
-            logging.warning("Disabled stats and daily notifications")
-            return
-
-        logging.info("Enabled stats for daily notifications")
+    def __init__(self, config: Config, notify_manager: NotifyManager):
+        self._config = config.get_stats_config()
         self._notify_manager = notify_manager
-        self._stat_accumulators = [
-            FoundProofStats(),
-            SearchTimeStats(),
-            NumberPlotsStats(),
-            EligiblePlotsStats(),
-            SignagePointStats(),
-        ]
+        self._stats_reporter: dict[str, StatReporter] = {}
+        self._initialize_stats_managers()
 
-        logging.info(f"Summary notifications will be sent out daily at {self._time_of_day} o'clock")
-        self._datetime_next_summary = datetime.now().replace(hour=self._time_of_day, minute=0, second=0, microsecond=0)
-        if datetime.now() > self._datetime_next_summary:
-            self._datetime_next_summary += timedelta(days=1)
+    def _initialize_stats_managers(self):
+        key_notifier_mapping = {
+            "daily_stats": DailyStatsReporter
+        }
 
-        # Start thread
-        self._is_running = True
-        self._thread = Thread(target=self._run_loop)
-        self._thread.start()
+        for key in self._config.keys():
+            if key not in key_notifier_mapping.keys():
+                logging.warning(f"Cannot find mapping for {key} notifier.")
+            if self._config[key]["enable"]:
+                self._stats_reporter[key] = key_notifier_mapping[key](
+                    notify_manager=self._notify_manager, config=self._config[key]
+                )
+
+        if len(self._stats_reporter.values()) == 0:
+            logging.warning("No stats reporter enabled")
+        else:
+            # Start thread
+            self._is_running = True
+            self._thread = Thread(target=self._run_loop)
+            self._thread.start()
 
     def consume_harvester_messages(self, objects: List[HarvesterActivityMessage]):
-        if not self._enable:
-            return
-        for stat_acc in self._stat_accumulators:
-            if isinstance(stat_acc, HarvesterActivityConsumer):
-                for obj in objects:
-                    stat_acc.consume(obj)
+        for key in self._stats_reporter.keys():
+            self._stats_reporter[key].consume_harvester_messages(objects)
 
     def consume_signage_point_messages(self, objects: List[FinishedSignagePointMessage]):
-        if not self._enable:
-            return
-        for stat_acc in self._stat_accumulators:
-            if isinstance(stat_acc, FinishedSignageConsumer):
-                for obj in objects:
-                    stat_acc.consume(obj)
-
-    def _send_daily_notification(self):
-        summary = "Hello farmer! 👋 Here's what happened in the last 24 hours:\n"
-        for stat_acc in self._stat_accumulators:
-            summary += "\n" + stat_acc.get_summary()
-            stat_acc.reset()
-
-        self._notify_manager.process_events(
-            [Event(type=EventType.DAILY_STATS, priority=EventPriority.LOW, service=EventService.DAILY, message=summary)]
-        )
+        for key in self._stats_reporter.keys():
+            self._stats_reporter[key].consume_signage_point_messages(objects)
 
     def _run_loop(self):
         while self._is_running:
-            if datetime.now() > self._datetime_next_summary:
-                self._send_daily_notification()
-                self._datetime_next_summary += timedelta(days=1)
+            for key in self._stats_reporter.keys():
+                self._stats_reporter[key].report()
             sleep(1)
 
     def stop(self):

--- a/src/config.py
+++ b/src/config.py
@@ -40,8 +40,8 @@ class Config:
     def get_keep_alive_monitor_config(self):
         return self._get_child_config("keep_alive_monitor", required=False)
 
-    def get_daily_stats_config(self):
-        return self._get_child_config("daily_stats")
+    def get_stats_config(self):
+        return self._get_child_config("stats")
 
 
 def check_keys(required_keys, config) -> bool:


### PR DESCRIPTION
This PR adds a stat reporter that reports accumulated stats to a HTTP endpoint.
It reuses the same stat_accumulators as the daily stats reporter, in a structured format.

The resulting event currently looks like this:
```
{
  'timestamp': 1620117180, 
  'found_proofs_total': 1, 
  'search_time_average': 0.32, 
  'search_time_over_5s_count': 3, 
  'search_time_over_15s_count': 0, 
  'current_plot_count': 1234, 
  'eligible_plots_average': 10.17, 
  'signage_point_count': 25, 
  'skipped_signage_point_count': 0
}
```