### PR TITLE
Improve skipped signage points

### DIFF
--- a/src/chia_log/handlers/condition_checkers/non_skipped_signage_points.py
+++ b/src/chia_log/handlers/condition_checkers/non_skipped_signage_points.py
@@ -29,9 +29,16 @@ class NonSkippedSignagePoints(FinishedSignageConditionChecker):
             return None
 
         event = None
-        skipped = calculate_skipped_signage_points(
+        valid, skipped = calculate_skipped_signage_points(
             self._last_signage_point_timestamp, self._last_signage_point, obj.timestamp, obj.signage_point
         )
+
+        if not valid:
+            # Reset state when we receive non-valid order of signage points
+            # this ensures that we aren't sending any wrongly calculated skips
+            self._last_signage_point_timestamp = None
+            self._last_signage_point = None
+            return None
 
         # To reduce notification spam, only send notifications for skips larger than 1
         # or for multiple individual skips within 1 hour

--- a/src/chia_log/handlers/daily_stats/stat_accumulators/signage_point_stats.py
+++ b/src/chia_log/handlers/daily_stats/stat_accumulators/signage_point_stats.py
@@ -24,9 +24,17 @@ class SignagePointStats(FinishedSignageConsumer, StatAccumulator):
             self._last_signage_point = obj.signage_point
             return
 
-        skips = calculate_skipped_signage_points(
+        valid, skips = calculate_skipped_signage_points(
             self._last_signage_point_timestamp, self._last_signage_point, obj.timestamp, obj.signage_point
         )
+
+        if not valid:
+            # Reset state when we receive non-valid order of signage points
+            # this ensures that we aren't sending any wrongly calculated skips
+            self._last_signage_point_timestamp = None
+            self._last_signage_point = None
+            return
+
         self._skips_total += skips
         self._total += 1
 

--- a/src/chia_log/handlers/util/calculate_skipped_signage_points.py
+++ b/src/chia_log/handlers/util/calculate_skipped_signage_points.py
@@ -1,14 +1,21 @@
 # std
 from datetime import datetime
+from typing import Tuple
 import logging
 
 roll_over_point = 64
 expected_diff_seconds = 9
 
 
-def calculate_skipped_signage_points(prev_ts: datetime, prev_id: int, curr_ts: datetime, curr_id: int):
-    """Calculate most likely amount of skipped signage points based on IDs and timestamps"""
+def calculate_skipped_signage_points(
+    prev_ts: datetime, prev_id: int, curr_ts: datetime, curr_id: int
+) -> Tuple[bool, int]:
+    """Calculate most likely amount of skipped signage points based on IDs and timestamps
+    If we detect out-of-order signage point event, the calculation is flagged as invalid.
 
+    :returns Validity and number of skipped signage points in case of valid calculation
+    """
+    valid = True
     diff_id = curr_id - prev_id
     diff_id_roll = (roll_over_point - prev_id) + curr_id
     diff_seconds = (curr_ts - prev_ts).seconds
@@ -17,13 +24,17 @@ def calculate_skipped_signage_points(prev_ts: datetime, prev_id: int, curr_ts: d
     # aren't necessarily related to the local node. See "testNetworkScramble" test case.
     # Signage points are expected approx every 8-10 seconds. If a point was skipped for real
     # then we expect the time difference to be at least 2*8 seconds. Otherwise it's flaky event.
+    # Update: Too fast blocks are leading to forks in the network. A fork is when 1 block gets
+    # reversed from the blockchain. When that happens, the full node clears all the signage points
+    # from the whole slot, and re-adds them. This is what happens here. We can invalidate the calculation.
     if diff_seconds < expected_diff_seconds * 1.5:
         if diff_id != 1 and diff_id_roll != 1:
-            logging.info(
+            valid = False
+            logging.debug(
                 f"Probably out of order signage point IDs {prev_id} and {curr_id} "
                 f"with timestamps {prev_ts} and {curr_ts}"
             )
-        return 0
+        return valid, 0
 
     one_roll_duration = roll_over_point * expected_diff_seconds
 
@@ -35,6 +46,6 @@ def calculate_skipped_signage_points(prev_ts: datetime, prev_id: int, curr_ts: d
     distance_to_expected_roll = abs(expected_diff_id - diff_id_roll)
 
     if distance_to_expected < distance_to_expected_roll:
-        return (diff_id + roll_over_point * roll_count) - 1
+        return valid, (diff_id + roll_over_point * roll_count) - 1
 
-    return (diff_id_roll + roll_over_point * roll_count) - 1
+    return valid, (diff_id_roll + roll_over_point * roll_count) - 1

--- a/src/notifier/mqtt_notifier.py
+++ b/src/notifier/mqtt_notifier.py
@@ -66,8 +66,10 @@ class MqttNotifier(Notifier):
         if self._username and self._password:
             self._client.username_pw_set(self._username, self._password)
         else:
-            logging.warning("You did not provide a username and password for connecting to the MQTT Broker. "
-                            "This might be indicative of a misconfigured config file")
+            logging.warning(
+                "You did not provide a username and password for connecting to the MQTT Broker. "
+                "This might be indicative of a misconfigured config file"
+            )
 
         self._client.connect(self._host, self._port)
         self._client.reconnect_delay_set()

--- a/tests/chia_log/handlers/util/test_calculate_skipped_signage_points.py
+++ b/tests/chia_log/handlers/util/test_calculate_skipped_signage_points.py
@@ -20,9 +20,10 @@ class TestCalculateSkippedSignagePoints(unittest.TestCase):
 
     def testNoSkips(self):
         for i in range(1, self.number):
-            skipped = calculate_skipped_signage_points(
+            valid, skipped = calculate_skipped_signage_points(
                 prev_ts=self.timestamps[i - 1], prev_id=self.ids[i - 1], curr_ts=self.timestamps[i], curr_id=self.ids[i]
             )
+            self.assertTrue(valid)
             self.assertEqual(skipped, 0)
 
     def testSingleSkips(self):
@@ -35,10 +36,15 @@ class TestCalculateSkippedSignagePoints(unittest.TestCase):
                 skip_ids.append(self.ids[i])
 
         total_skipped = 0
+        all_valid = True
         for i in range(1, len(skip_ids)):
-            total_skipped += calculate_skipped_signage_points(
+            valid, skips = calculate_skipped_signage_points(
                 prev_ts=skip_tss[i - 1], prev_id=skip_ids[i - 1], curr_ts=skip_tss[i], curr_id=skip_ids[i]
             )
+            all_valid = all_valid and valid
+            total_skipped += skips
+
+        self.assertTrue(all_valid)
         self.assertEqual(len(skip_indices), total_skipped)
 
     def testMultipleSkipsInRow(self):
@@ -51,10 +57,15 @@ class TestCalculateSkippedSignagePoints(unittest.TestCase):
                 skip_ids.append(self.ids[i])
 
         total_skipped = 0
+        all_valid = True
         for i in range(1, len(skip_ids)):
-            total_skipped += calculate_skipped_signage_points(
+            valid, skips = calculate_skipped_signage_points(
                 prev_ts=skip_tss[i - 1], prev_id=skip_ids[i - 1], curr_ts=skip_tss[i], curr_id=skip_ids[i]
             )
+            all_valid = all_valid and valid
+            total_skipped += skips
+
+        self.assertTrue(all_valid)
         self.assertEqual(len(skip_indices), total_skipped)
 
     def testMultiRolloverSkip(self):
@@ -67,10 +78,15 @@ class TestCalculateSkippedSignagePoints(unittest.TestCase):
                 skip_ids.append(self.ids[i])
 
         total_skipped = 0
+        all_valid = True
         for i in range(1, len(skip_ids)):
-            total_skipped += calculate_skipped_signage_points(
+            valid, skips = calculate_skipped_signage_points(
                 prev_ts=skip_tss[i - 1], prev_id=skip_ids[i - 1], curr_ts=skip_tss[i], curr_id=skip_ids[i]
             )
+            all_valid = all_valid and valid
+            total_skipped += skips
+
+        self.assertTrue(all_valid)
         self.assertEqual(len(skip_indices), total_skipped)
 
 


### PR DESCRIPTION
* Dowgrade log output about out-of-order events to debug log level to
  reduce questions and concerns about this (expected) phenomenon
* Add clarification to the comment explaining when it happens
* Add validity flag in the return that allows the users of the function
  to clear their state from wrong previous SP records. Thus preventing
  incorrect signage point skip notifications.