### PR TITLE
Add Docker instructions

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,59 @@
+## Installation on Docker
+
+### Clone the repository
+
+```
+git clone https://github.com/martomi/chiadog.git
+cd chiadog
+```
+
+### Build the Docker image
+
+#### Latest version
+
+```
+docker image build -t chiadog:latest .
+```
+
+#### Specific version
+
+```
+docker image build -t chiadog:0.5.0 --build-arg BRANCH=v0.5.0 .
+```
+
+### Copy the example config file
+
+```
+cp config-example.yaml config.yaml
+```
+
+### Edit the configuration
+
+Open up `config.yaml` in your editor and configure it to your preferences.
+
+## Monitoring a local harvester / farmer
+
+### Start the watchdog
+
+```
+docker run --name chiadog --rm -v ${HOME}/.chia/mainnet/log/debug.log:/chiadog/debug.log:ro \
+    -v ${PWD}/config.yaml:/chiadog/config.yaml:ro -d \
+    chiadog:${VERSION}
+```
+
+You should adapt the following options to your environment:
+ - `${HOME}/.chia/mainnet/log/debug.log` should be replaced by the path of your `debug.log` file
+ - `/chiadog/debug.log` should be replaced by the value of `chia_logs.file_log_consumer.file_path` setting
+ - `${VERSION}` should be replaced by the version of the previously built Docker image
+
+### Verify that your plots are detected
+
+```
+docker logs -f chiadog
+```
+
+Within a few seconds you should see INFO log:
+
+```
+Detected new plots. Farming with 42 plots.
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:latest
+
+ARG BRANCH=main
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+ && apt-get install -y git python3 python3-venv
+
+RUN echo "cloning ${BRANCH}"
+RUN git clone --branch ${BRANCH} https://github.com/martomi/chiadog.git \
+ && cd chiadog \
+ && /usr/bin/sh ./install.sh
+
+WORKDIR /chiadog
+ENTRYPOINT ["bash", "./start.sh"]

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ For detailed guide on how to test and configure, please refer to [INTEGRATIONS.m
 - [Git](https://git-scm.com/downloads)
 - Enabled `INFO` logs on your chia farmer
 
-The instructions below are specific to Linux and MacOS, for installing `chiadog` on Windows, please refer
-to this separate [README](WINDOWS.md) section.
+The instructions below are specific to **Linux and MacOS**. For installing `chiadog` on **Windows**, please refer
+to this separate [README](WINDOWS.md) section. For installing `chiadog` using **Docker**, please refer to this separate
+[README](DOCKER.md) section.
 
 ### How to enable INFO logs on chia farmer?
 


### PR DESCRIPTION
I'm running Chia on Docker using the [official Chia Docker container](https://github.com/Chia-Network/chia-docker). I wanted to integrate `chiadog` to my Docker environment so this commit brings a Dockerfile and instructions on how to setup `chiadog` using Docker.