### PR TITLE
Fix harvester activity parser regexp to support more than 9 matching …

### DIFF
--- a/src/chia_log/parsers/harvester_activity_parser.py
+++ b/src/chia_log/parsers/harvester_activity_parser.py
@@ -31,7 +31,7 @@ class HarvesterActivityParser:
     def __init__(self):
         logging.info("Enabled parser for harvester activity - eligible plot events.")
         self._regex = re.compile(
-            r"([0-9:.]*) harvester (?:src|chia).harvester.harvester(?:\s?): INFO\s*([0-9]) plots were "
+            r"([0-9:.]*) harvester (?:src|chia).harvester.harvester(?:\s?): INFO\s*([0-9]+) plots were "
             r"eligible for farming ([0-9a-z.]*) Found ([0-9]) proofs. Time: ([0-9.]*) s. "
             r"Total ([0-9]*) plots"
         )


### PR DESCRIPTION
…plots

Without this change, logs like this one were not correctly parsed:

harvester chia.harvester.harvester: INFO     10 plots were eligible for farming c599f64427... Found 0 proofs. Time: 0.45573 s. Total X plots