### PR TITLE
SignagePoints: Fix wrong handling of fork events

### DIFF
--- a/tests/chia_log/handlers/test_finished_signage_point_handler.py
+++ b/tests/chia_log/handlers/test_finished_signage_point_handler.py
@@ -58,6 +58,16 @@ class TestFinishedSignagePointHandler(unittest.TestCase):
             events = self.handler.handle(log)
             self.assertEqual(len(events), 0)
 
+    def testNetworkFork(self):
+        """Cover a use-case of a network fork combined with some delays between signage points.
+        See the network_fork.txt for reference. This is taken from a real-world event."""
+        with open(self.example_logs_path / "network_fork.txt", encoding="UTF-8") as f:
+            logs = f.readlines()
+
+        for log in logs:
+            events = self.handler.handle(log)
+            self.assertEqual(len(events), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/chia_log/logs/finished_signage_point/network_fork.txt
+++ b/tests/chia_log/logs/finished_signage_point/network_fork.txt
@@ -1,0 +1,15 @@
+2021-05-13T22:12:25.148 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 60/64:
+2021-05-13T22:12:35.081 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 61/64:
+2021-05-13T22:12:41.911 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 62/64:
+2021-05-13T22:12:49.784 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 63/64:
+2021-05-13T22:12:58.453 full_node chia.full_node.full_node: INFO     ⏲️  Finished sub slot, SP 64/64,
+2021-05-13T22:13:07.659 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 1/64:
+2021-05-13T22:13:14.053 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 2/64:
+2021-05-13T22:13:42.341 full_node chia.full_node.full_node: INFO     ⏲️  Finished sub slot, SP 64/64,
+2021-05-13T22:13:50.884 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 1/64:
+2021-05-13T22:13:58.247 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 2/64:
+2021-05-13T22:14:06.288 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 3/64:
+2021-05-13T22:14:14.181 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 4/64:
+2021-05-13T22:14:22.166 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 5/64:
+2021-05-13T22:14:30.104 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 6/64:
+2021-05-13T22:14:38.398 full_node chia.full_node.full_node: INFO     ⏲️  Finished signage point 7/64:


### PR DESCRIPTION
* Add test case for network fork
* Fix logic to handle this case properly

Fixes: #116

Should result in less false alarms.