### PR TITLE
Fix black error

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -36,6 +36,7 @@ jobs:
         git config --global user.name 'autoblack'
         git config --global user.email 'martomi@users.noreply.github.com'
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+        git fetch
         git checkout $GITHUB_HEAD_REF
         git commit -am "fixup: Format Python code with Black"
         git push

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -35,6 +35,7 @@ jobs:
         git config --global user.name 'autoblack'
         git config --global user.email 'martomi@users.noreply.github.com'
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+        git fetch
         git checkout $GITHUB_HEAD_REF
         black src tests
         git commit -am "fixup: Format Python code with Black"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -27,19 +27,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install black flake8 mypy
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Format check with Black
-      run: black --check src tests
-    - name: If needed, commit black changes to the pull request
-      if: failure()
-      run: |
-        git config --global user.name 'autoblack'
-        git config --global user.email 'martomi@users.noreply.github.com'
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
-        git fetch
-        git checkout $GITHUB_HEAD_REF
-        black src tests
-        git commit -am "fixup: Format Python code with Black"
-        git push
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -52,3 +39,13 @@ jobs:
     - name: Unit Tests
       run: |
         python -m unittest
+    - name: Format check with Black
+      run: |
+        git config --global user.name 'autoblack'
+        git config --global user.email 'martomi@users.noreply.github.com'
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+        git fetch
+        git checkout $GITHUB_HEAD_REF
+        black src tests
+        git commit -am "fixup: Format Python code with Black"
+        git push

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -32,12 +32,12 @@ jobs:
     - name: If needed, commit black changes to the pull request
       if: failure()
       run: |
+        black src tests
         git config --global user.name 'autoblack'
         git config --global user.email 'martomi@users.noreply.github.com'
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
         git fetch
         git checkout $GITHUB_HEAD_REF
-        black src tests
         git commit -am "fixup: Format Python code with Black"
         git push
     - name: Lint with flake8

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -36,7 +36,6 @@ jobs:
         git config --global user.name 'autoblack'
         git config --global user.email 'martomi@users.noreply.github.com'
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
-        git fetch
         git checkout $GITHUB_HEAD_REF
         git commit -am "fixup: Format Python code with Black"
         git push

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -32,11 +32,11 @@ jobs:
     - name: If needed, commit black changes to the pull request
       if: failure()
       run: |
-        black src tests
         git config --global user.name 'autoblack'
         git config --global user.email 'martomi@users.noreply.github.com'
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
         git checkout $GITHUB_HEAD_REF
+        black src tests
         git commit -am "fixup: Format Python code with Black"
         git push
     - name: Lint with flake8

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -32,12 +32,12 @@ jobs:
     - name: If needed, commit black changes to the pull request
       if: failure()
       run: |
-        black src tests
         git config --global user.name 'autoblack'
         git config --global user.email 'martomi@users.noreply.github.com'
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
         git fetch
         git checkout $GITHUB_HEAD_REF
+        black src tests
         git commit -am "fixup: Format Python code with Black"
         git push
     - name: Lint with flake8

--- a/src/chia_log/log_consumer.py
+++ b/src/chia_log/log_consumer.py
@@ -232,13 +232,7 @@ def create_log_consumer_from_config(config: dict) -> Optional[LogConsumer]:
         )
 
         if platform == OS.WINDOWS:
-            return WindowsNetworkLogConsumer(
-                remote_log_path=path,
-                remote_host=enabled_consumer_config["remote_host"],
-                remote_user=enabled_consumer_config["remote_user"],
-                remote_port=remote_port,
-                remote_platform=platform,
-            )
+            return WindowsNetworkLogConsumer(remote_log_path=path, remote_host=enabled_consumer_config["remote_host"], remote_user=enabled_consumer_config["remote_user"], remote_port=remote_port, remote_platform=platform,)
         else:
             return PosixNetworkLogConsumer(
                 remote_log_path=path,

--- a/src/chia_log/log_consumer.py
+++ b/src/chia_log/log_consumer.py
@@ -183,13 +183,7 @@ def create_log_consumer_from_config(config: dict) -> Optional[LogConsumer]:
             remote_port,
         )
 
-        return NetworkLogConsumer(
-            remote_log_path=path,
-            remote_host=enabled_consumer_config["remote_host"],
-            remote_user=enabled_consumer_config["remote_user"],
-            remote_port=remote_port,
-            remote_platform=platform,
-        )
+        return NetworkLogConsumer(remote_log_path=path, remote_host=enabled_consumer_config["remote_host"], remote_user=enabled_consumer_config["remote_user"], remote_port=remote_port, remote_platform=platform,)
 
     logging.error("Unhandled consumer type")
     return None

--- a/src/chia_log/log_consumer.py
+++ b/src/chia_log/log_consumer.py
@@ -232,7 +232,13 @@ def create_log_consumer_from_config(config: dict) -> Optional[LogConsumer]:
         )
 
         if platform == OS.WINDOWS:
-            return WindowsNetworkLogConsumer(remote_log_path=path, remote_host=enabled_consumer_config["remote_host"], remote_user=enabled_consumer_config["remote_user"], remote_port=remote_port, remote_platform=platform,)
+            return WindowsNetworkLogConsumer(
+                remote_log_path=path,
+                remote_host=enabled_consumer_config["remote_host"],
+                remote_user=enabled_consumer_config["remote_user"],
+                remote_port=remote_port,
+                remote_platform=platform,
+            )
         else:
             return PosixNetworkLogConsumer(
                 remote_log_path=path,


### PR DESCRIPTION
When running an unsuccessful `black` format check the script automatically runs the formatter and commits the altered source code.

This currently results in an error:
```
Run black src tests
reformatted src/chia_log/log_consumer.py
All done! ✨ 🍰 ✨
1 file reformatted, 62 files left unchanged.
error: pathspec 'feature/improve-harvester-offline' did not match any file(s) known to git
Error: Process completed with exit code 1.
```

Adding `git fetch` potentially solves this error.