### PR TITLE
NonDecreasingPlots: Increase tolerance threshold to 2

### DIFF
--- a/src/chia_log/handlers/condition_checkers/non_decreasing_plots.py
+++ b/src/chia_log/handlers/condition_checkers/non_decreasing_plots.py
@@ -17,6 +17,9 @@ class NonDecreasingPlots(HarvesterConditionChecker):
     def __init__(self):
         logging.info("Enabled check for non-decreasing total plot count.")
         self._max_farmed_plots = 0
+        # When copying plots it's common that plots decrease by 1 temporarily
+        # by setting the default threshold to 2, we can avoid false alarms
+        self._decrease_warn_threshold = 2
 
     def check(self, obj: HarvesterActivityMessage) -> Optional[Event]:
         if obj.total_plots_count > self._max_farmed_plots:
@@ -25,14 +28,20 @@ class NonDecreasingPlots(HarvesterConditionChecker):
 
         event = None
         if obj.total_plots_count < self._max_farmed_plots:
-            message = (
-                f"Disconnected HDD? The total plot count decreased from "
-                f"{self._max_farmed_plots} to {obj.total_plots_count}."
-            )
-            logging.warning(message)
-            event = Event(
-                type=EventType.USER, priority=EventPriority.HIGH, service=EventService.HARVESTER, message=message
-            )
+            if self._max_farmed_plots - obj.total_plots_count < self._decrease_warn_threshold:
+                logging.info(
+                    f"Plots decreased from {self._max_farmed_plots} to {obj.total_plots_count}. "
+                    f"This is ignored because it's below threshold of {self._decrease_warn_threshold}"
+                )
+            else:
+                message = (
+                    f"Disconnected HDD? The total plot count decreased from "
+                    f"{self._max_farmed_plots} to {obj.total_plots_count}."
+                )
+                logging.warning(message)
+                event = Event(
+                    type=EventType.USER, priority=EventPriority.HIGH, service=EventService.HARVESTER, message=message
+                )
 
         # Update max plots to prevent repeated alarms
         self._max_farmed_plots = obj.total_plots_count

--- a/tests/chia_log/logs/harvester_activity/plots_decreased.txt
+++ b/tests/chia_log/logs/harvester_activity/plots_decreased.txt
@@ -1,5 +1,5 @@
 10:39:36.535 harvester chia.harvester.harvester: INFO     0 plots were eligible for farming e25et6cb36... Found 0 proofs. Time: 0.55515 s. Total 42 plots
-10:39:45.931 harvester chia.harvester.harvester: INFO     1 plots were eligible for farming e25et6cb36... Found 0 proofs. Time: 1.05515 s. Total 43 plots
+10:39:45.931 harvester chia.harvester.harvester: INFO     1 plots were eligible for farming e25et6cb36... Found 0 proofs. Time: 1.05515 s. Total 41 plots
 10:39:54.412 harvester chia.harvester.harvester: INFO     2 plots were eligible for farming e25et6cb36... Found 0 proofs. Time: 0.23412 s. Total 43 plots
 10:40:03.331 harvester chia.harvester.harvester: INFO     3 plots were eligible for farming e25et6cb36... Found 0 proofs. Time: 0.12348 s. Total 30 plots
 10:40:12.112 harvester chia.harvester.harvester: INFO     0 plots were eligible for farming e25et6cb36... Found 0 proofs. Time: 0.34952 s. Total 30 plots


### PR DESCRIPTION
Closes #147
Closes #58

I see little value in making refactors and adding additional
configuration parameters for this. A threshold of 2 should resolve all
issues that are experienced during copying of plots.

Note that 2 is an instantenous threshold since the max value gets reset
after that. Meaning that plot count may drop by 10 without a
notification as long as its dropping in steps of 1.

For transparency of what is happening, I've added an info log that is
always triggered, regardless of the threshold.

The test case is adjusted to contain a scenario with decreasing plot
count by 1 which is expected not to trigger a notification.