### PR TITLE
FileLogConsumer: Throttle log polling

### DIFF
--- a/src/chia_log/log_consumer.py
+++ b/src/chia_log/log_consumer.py
@@ -71,6 +71,7 @@ class FileLogConsumer(LogConsumer):
     @retry((FileNotFoundError, PermissionError), delay=2)
     def _consume_loop(self):
         while self._is_running:
+            sleep(1)  # throttle polling for new logs
             for log_line in Pygtail(self._expanded_log_path, read_from_end=True, offset_file=self._offset_path):
                 self._notify_subscribers(log_line)
 


### PR DESCRIPTION
Currently the loop isn't throttled which creates busy-wait and maxes out
one of the CPU cores to 100%. This is because Pygtail exits its own loop
every time it reaches the end of the debug.log file.

This also makes WARNING logs about non-existing debug.log file during
log rotation statistically improbable.