### PR TITLE
Events: Bring back the found proof notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ helps with automated monitoring and sends you a mobile notification in case some
 | Harvester | Experiencing networking issues? Harvester did not participate in any challenge for 120 seconds. It's now working again. | NORMAL |
 | Harvester | Seeking plots took too long: 21.42 seconds! | NORMAL |
 | Full Node | Experiencing networking issues? Skipped 42 signage points! | NORMAL |
+| Harvester | Found 1 proof(s)! | LOW |
 | Wallet | Cha-ching! Just received 2.0 XCH ☘️ | LOW |
 | Daily Stats | Hello farmer! 👋 Here's what happened in the last 24 hours: <br /><br /> Received ☘️: **2.00** XCH️<br /> Proofs 🧾: **2** found<br /> Search 🔍: <br /> - average: **0.46**s <br /> - over 5s: 2 occasions <br /> - over 15s: 1 occasions <br/> Plots 🌱: **42**, new: **2** <br /> Eligible plots 🥇: **0.08** average<br /> Skipped SPs ⚠️: 7 (0.01%) <br /> | LOW |
 

--- a/src/chia_log/handlers/condition_checkers/found_proofs.py
+++ b/src/chia_log/handlers/condition_checkers/found_proofs.py
@@ -1,0 +1,25 @@
+# std
+import logging
+from typing import Optional
+
+# project
+from src.notifier import Event, EventService, EventType, EventPriority
+from . import HarvesterConditionChecker
+from ...parsers.harvester_activity_parser import HarvesterActivityMessage
+
+
+class FoundProofs(HarvesterConditionChecker):
+    """Check if any proofs were found."""
+
+    def __init__(self):
+        logging.info("Enabled check for found proofs.")
+
+    def check(self, obj: HarvesterActivityMessage) -> Optional[Event]:
+        if obj.found_proofs_count > 0:
+            message = f"Found {obj.found_proofs_count} proof(s)!"
+            logging.info(message)
+            return Event(
+                type=EventType.USER, priority=EventPriority.LOW, service=EventService.HARVESTER, message=message
+            )
+
+        return None

--- a/src/chia_log/handlers/harvester_activity_handler.py
+++ b/src/chia_log/handlers/harvester_activity_handler.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 from . import LogHandler
 from ..parsers.harvester_activity_parser import HarvesterActivityParser
 from .condition_checkers import HarvesterConditionChecker
+from .condition_checkers.found_proofs import FoundProofs
 from .condition_checkers.non_decreasing_plots import NonDecreasingPlots
 from .condition_checkers.quick_plot_search_time import QuickPlotSearchTime
 from .condition_checkers.time_since_last_farm_event import TimeSinceLastFarmEvent
@@ -26,6 +27,7 @@ class HarvesterActivityHandler(LogHandler):
             TimeSinceLastFarmEvent(),
             NonDecreasingPlots(),
             QuickPlotSearchTime(),
+            FoundProofs(),
         ]
 
     def handle(self, logs: str, stats_manager: Optional[StatsManager] = None) -> List[Event]:

--- a/tests/chia_log/handlers/test_harvester_activity_handler.py
+++ b/tests/chia_log/handlers/test_harvester_activity_handler.py
@@ -16,12 +16,20 @@ class TestHarvesterActivityHandler(unittest.TestCase):
         with open(self.example_logs_path / "nominal.txt", encoding="UTF-8") as f:
             logs = f.readlines()
 
-        for log in logs:
+        # Third log should trigger an event for a found proof
+        expected_number_events = [1, 1, 2, 1, 1]
+
+        for log, number_events in zip(logs, expected_number_events):
             events = self.handler.handle(log)
-            self.assertEqual(len(events), 1, "Only expecting 1 event for keep-alive")
+            self.assertEqual(len(events), number_events, "Only expecting 1 event for keep-alive")
             self.assertEqual(events[0].type, EventType.KEEPALIVE, "Unexpected event type")
             self.assertEqual(events[0].priority, EventPriority.NORMAL, "Unexpected priority")
             self.assertEqual(events[0].service, EventService.HARVESTER, "Unexpected service")
+            if number_events == 2:
+                self.assertEqual(events[1].type, EventType.USER, "Unexpected event type")
+                self.assertEqual(events[1].priority, EventPriority.LOW, "Unexpected priority")
+                self.assertEqual(events[1].service, EventService.HARVESTER, "Unexpected service")
+                self.assertEqual(events[1].message, "Found 1 proof(s)!")
 
     def testDecreasedPlots(self):
         with open(self.example_logs_path / "plots_decreased.txt", encoding="UTF-8") as f:


### PR DESCRIPTION
closes #167
closes #182

The wallet events that were supposed to replace these notifications do
not work in many of the scenarious that chiadog operates in.

This commit reverses the removal of the found proof notifications.