### PR TITLE
Fix install script package checks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,8 @@
+#!/bin/bash
+
 # Function that checks if a package is installed locally
 function package_installed() {
-  return dpkg -l "$1" &> /dev/null
+  dpkg -s "$1" &> /dev/null
 }
 
 # Check Python version


### PR DESCRIPTION
Removes the return statement that always causes the packages
check to fail.

Recognises removed packages should be installed again.