### PR TITLE
Add config option to disable SMTP auth for basic postfix setup

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -64,6 +64,7 @@ notifier:
       recipient: 'you@example.com'
       username_smtp: 'username'
       password_smtp: 'password'
+      enable_smtp_auth: true
       host: 'smtp.example.com'
       port: 587
   script:

--- a/src/notifier/smtp_notifier.py
+++ b/src/notifier/smtp_notifier.py
@@ -24,7 +24,7 @@ class SMTPNotifier(Notifier):
             self.password_smtp = credentials["password_smtp"]
             self.host = credentials["host"]
             self.port = credentials["port"]
-            self.enable_smtp_auth = credentials["enable_smtp_auth"]
+            self.enable_smtp_auth = credentials.get("enable_smtp_auth", True)
 
         except KeyError as key:
             logging.error(f"Invalid config.yaml. Missing key: {key}")

--- a/src/notifier/smtp_notifier.py
+++ b/src/notifier/smtp_notifier.py
@@ -24,6 +24,7 @@ class SMTPNotifier(Notifier):
             self.password_smtp = credentials["password_smtp"]
             self.host = credentials["host"]
             self.port = credentials["port"]
+            self.enable_smtp_auth = credentials["enable_smtp_auth"]
 
         except KeyError as key:
             logging.error(f"Invalid config.yaml. Missing key: {key}")
@@ -57,7 +58,8 @@ class SMTPNotifier(Notifier):
                     server.starttls()
                     # stmplib docs recommend calling ehlo() before & after starttls()
                     server.ehlo()
-                    server.login(self.username_smtp, self.password_smtp)
+                    if self.enable_smtp_auth:
+                        server.login(self.username_smtp, self.password_smtp)
                     server.sendmail(self.sender, self.recipient, msg.as_string())
                     server.quit()
                 # Display an error message if something goes wrong.


### PR DESCRIPTION
Sometimes it is useful to disable SMTP authentication for sending emails. For example, if someone is using a local `postfix` server, the default install doesn't require/enable auth. 

When this new config option is set to `enable_smtp_auth: false`, the `username_smtp` and `password_smtp` config options are ignored. 