### PR TITLE
Sandboxed systemd service

### DIFF
--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -17,6 +17,18 @@ Test with:
 PUSHOVER_API_TOKEN=<api_token> PUSHOVER_USER_KEY=<user_key> python3 -m unittest tests.notifier.test_pushover_notifier
 ```
 
+## Pushcut
+
+[Pushcut](https://pushcut.io/) is available for both Android and iOS. High priority notifications can be configured
+from the Pushcut app to overwrite any Silence or Do-Not-Disturb modes on your phone and sound a loud alarm at any time
+of the day to make you aware of any issues in a timely manner.
+
+Test with:
+
+```
+PUSHCUT_API_TOKEN=<api_token> PUSHCUT_NOTIFICATION_NAME=<notification_name> python3 -m unittest tests.notifier.test_pushcut_notifier
+```
+
 ## SMTP / E-Mail
 
 This integration uses SMTP to send an e-mail to a designated address. Alert information is sent in the subject line of

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -147,6 +147,16 @@ Test with:
 GRAFANA_BASE_URL=<webhook_url> GRAFANA_API_TOKEN=<api_token> python3 -m unittest tests.notifier.test_grafana_notifier
 ```
 
+## Ifttt
+
+[Ifttt](https://ifttt.com/) is available for both Android and iOS. Can be used to send push notifications and to integrate with various other APIs.  For example if you wanted to flash a Philips hue lightbulb when you have a Chiadog notification.
+
+Test with:
+
+```
+IFTTT_API_TOKEN=<api_token> IFTTT_WEBHOOK_NAME=<user_key> python3 -m unittest tests.notifier.test_ifttt_notifier
+```
+
 ## Unit Testing on Windows
 
 When running unit tests on Windows, you will want to use PowerShell to set environment variables like this:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ helps with automated monitoring and sends you a mobile notification in case some
 | ------------- | ------------- | ------|
 | Harvester | Your harvester appears to be offline! No events for the past 400 seconds. | HIGH |
 | Harvester | Disconnected HDD? The total plot count decreased from 100 to 40. | HIGH |
+| Harvester | Connected HDD? The total plot count increased from 0 to 42. | LOW |
 | Harvester | Experiencing networking issues? Harvester did not participate in any challenge for 120 seconds. It's now working again. | NORMAL |
 | Harvester | Seeking plots took too long: 21.42 seconds! | NORMAL |
 | Full Node | Experiencing networking issues? Skipped 42 signage points! | NORMAL |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You may use one (or more) of the following integrations to receive notifications
 | Integration | Advantages | Cost |
 | ------------- | ------------- | ------|
 | [Pushover](https://pushover.net/) | High priority notifications that can override your phone's silent mode. | $5 one time purchase after 30 day trial. |
+| [Pushcut](https://pushcut.io/) | Alternative to Pushover |
 | E-mail | You probably already have an email. No additional apps. | Free |
 | Slack | Quick & easy setup. | Free |
 | Discord | Quick & easy setup. | Free |

--- a/README.md
+++ b/README.md
@@ -196,16 +196,19 @@ nohup python3 -u main.py --config config.yaml > output.log 2>&1 &
 To stop chiadog, you can find the Process ID (PID) via `ps aux | grep main.py` and then softly interrupt the process
 with `kill -SIGINT <pid_here>`.
 
+You can also run chiadog as a sandboxed systemd service.
+
 ## Running `chiadog` in sandboxed environment
 
-We're in the early stages of exploring the best way to provide easy to setup sandboxed environment where the `chiadog`
-process is completely isolated from potentially accessing your private keys. Contributions in that direction are very
-welcome. Meanwhile you can check out @ajacobson repository
-for [chiadog-docker](https://github.com/ajacobson/chiadog-docker).
+We're still exploring the best way to provide easy to setup sandboxed environment where the `chiadog` process is
+completely isolated from potentially accessing your private keys. Contributions in that direction are very welcome.
 
-Alternatively, [as suggested here](https://github.com/martomi/chiadog/issues/24) you can run `chiadog` from a unix user
-with limited permissions.
-
+* There is an example [systemd service](scripts/linux/chiadog.service) you can configure which runs chiadog as a limited
+user and blocks access to key chia locations.
+* Alternatively, [as suggested here](https://github.com/martomi/chiadog/issues/24) you can run `chiadog` from a unix
+user with limited permissions.
+* For running in docker, you can check out @ajacobson repository for
+[chiadog-docker](https://github.com/ajacobson/chiadog-docker).
 # Contributing
 
 Contributions are always welcome! Please refer to [CONTRIBUTING](CONTRIBUTING.md) documentation.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ You may use one (or more) of the following integrations to receive notifications
 | Shell script (beta) | Execute anything in your own script. | Free |
 | MQTT | Well-suited for Home Automation. | Free | 
 | Grafana | For hardware monitoring. | Free |
+| [Ifttt](https://ifttt.com/) | Can be used to send push notifications or to do other API integrations depending on incoming data. | Free |
+
 
 For detailed guide on how to test and configure, please refer to [INTEGRATIONS.md](INTEGRATIONS.md).
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -109,3 +109,10 @@ notifier:
       api_token: ''
       dashboard_id: -1
       panel_id: -1
+  ifttt:
+    enable: false
+    daily_stats: false
+    wallet_events: false
+    credentials:
+      api_token: 'dummy_token'
+      webhook_name: 'dummy_key'

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -47,6 +47,13 @@ notifier:
     credentials:
       api_token: 'dummy_token'
       user_key: 'dummy_key'
+  pushcut:
+    enable: false
+    daily_stats: true
+    wallet_events: true
+    credentials:
+      api_token: 'dummy_token'
+      user_key: 'dummy_key'
   telegram:
     enable: false
     daily_stats: true

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -44,6 +44,8 @@ notifier:
     enable: false
     daily_stats: true
     wallet_events: true
+    decreasing_plot_events: true
+    increasing_plot_events: false
     credentials:
       api_token: 'dummy_token'
       user_key: 'dummy_key'
@@ -51,6 +53,8 @@ notifier:
     enable: false
     daily_stats: true
     wallet_events: true
+    decreasing_plot_events: true
+    increasing_plot_events: false
     credentials:
       api_token: 'dummy_token'
       user_key: 'dummy_key'
@@ -58,6 +62,8 @@ notifier:
     enable: false
     daily_stats: true
     wallet_events: true
+    decreasing_plot_events: true
+    increasing_plot_events: false
     credentials:
       bot_token: 'dummy_bot_token'
       chat_id: 'dummy_chat_id'
@@ -65,6 +71,8 @@ notifier:
     enable: false
     daily_stats: true
     wallet_events: true
+    decreasing_plot_events: true
+    increasing_plot_events: false
     credentials:
       sender: 'chia@example.com'
       sender_name: 'chiadog'
@@ -77,23 +85,31 @@ notifier:
     enable: false
     daily_stats: true
     wallet_events: true
+    decreasing_plot_events: true
+    increasing_plot_events: false
     script_path: 'tests/test_script.sh'
   discord:
     enable: false
     daily_stats: true
     wallet_events: true
+    decreasing_plot_events: true
+    increasing_plot_events: false
     credentials:
       webhook_url: 'https://discord.com/api/webhooks/...'
   slack:
     enable: false
     daily_stats: true
     wallet_events: true
+    decreasing_plot_events: true
+    increasing_plot_events: false
     credentials:
       webhook_url: 'https://hooks.slack.com/services/...'
   mqtt:
     enable: false
     daily_stats: true
     wallet_events: true
+    decreasing_plot_events: true
+    increasing_plot_events: false
     topic: chia/chiadog/alert
     qos: 1
     retain: false
@@ -113,6 +129,8 @@ notifier:
     enable: false
     daily_stats: false
     wallet_events: false
+    decreasing_plot_events: true
+    increasing_plot_events: false
     credentials:
       api_token: 'dummy_token'
       webhook_name: 'dummy_key'

--- a/install.sh
+++ b/install.sh
@@ -13,12 +13,13 @@ then
   exit 1
 fi
 
-# Check existence of required python build packages
-if ! package_installed libpython3-dev || ! package_installed build-essential; then
-  sudo apt-get update
-  sudo apt-get install libpython3-dev build-essential -y
+# Check existence of required python build packages for non-MacOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+  if ! package_installed libpython3-dev || ! package_installed build-essential; then
+    sudo apt-get update
+    sudo apt-get install libpython3-dev build-essential -y
+  fi
 fi
-
 # Create virtual environment
 python3 -m venv venv
 

--- a/main.py
+++ b/main.py
@@ -53,12 +53,6 @@ def init(config:Config):
 
     logging.info(f"Starting Chiadog ({version()})")
 
-    # Remove the Pygtail offset file if it exists
-    # Fixes a bug where hard reboot corrupts the offset file
-    offset = Config.get_log_offset_path()
-    if offset.exists():
-        offset.unlink()
-
     # Create log consumer based on provided configuration
     chia_logs_config = config.get_chia_logs_config()
     log_consumer = create_log_consumer_from_config(chia_logs_config)

--- a/scripts/linux/chiadog.service
+++ b/scripts/linux/chiadog.service
@@ -1,0 +1,81 @@
+# Runs chiadog as a limited service
+#
+# It requires at least systemd 235 for the sandboxing features,
+# although it will run without them on earlier versions.
+#
+# Replace {home-path} and {path-to-chiadog} with your absolute
+# paths before copying it to your systemd directory -
+#
+# /etc/systemd/system/chiadog.service
+#
+# It can then be run by reloading services and starting it -
+#
+# > sudo systemctl daemon-reload
+# > sudo systemctl start chiadog
+#
+# You can watch the log output by using -
+#
+# > sudo journalctl -u chiadog -f
+#
+# You can also review the security policy by using -
+#
+# > systemd-analyze security chiadog.service
+#
+
+[Unit]
+Description=chiadog
+Wants=network-online.target
+After=network.target network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+
+# Create a new user with limited access each time the service is started
+DynamicUser=yes
+
+# Hide any important chia files (such as the wallet keys)
+#
+# It's important to update these paths as chia adds any new directories we want to hide,
+# as there's no way to hide everything *except* for log/debug.log (without using newer,
+# less supported temporary filesystem features).
+#
+# You could also configure chia to place the log file outside of ~/.chia, and then block
+# the entire ~./chia directory if you prefer.
+#
+InaccessiblePaths=/{home-path}/.chia/mainnet/config /{home-path}/.chia/mainnet/wallet /{home-path}/.chia/mainnet/db /{home-path}/.chia/mainnet/run
+
+# Absolute path to chiadog such as /home/my-user/chiadog
+WorkingDirectory=/{path-to-chiadog}
+
+# Using the python from venv bin will activate the environment automatically  
+ExecStart=/{path-to-chiadog}/venv/bin/python -u main.py --config config.yaml
+
+Restart=always
+RestartSec=1
+
+# Allow chiadog to shut down smoothly
+KillSignal=SIGINT
+
+# Lock down the service further
+# See https://www.digitalocean.com/community/tutorials/how-to-sandbox-processes-with-systemd-on-ubuntu-20-04
+# as well as https://gist.github.com/ageis/f5595e59b1cddb1513d1b425a323db04
+SystemCallFilter=@system-service
+NoNewPrivileges=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+MemoryDenyWriteExecute=yes
+RestrictRealtime=yes
+PrivateDevices=yes
+ProtectHostname=yes
+PrivateUsers=yes
+RestrictNamespaces=yes
+CapabilityBoundingSet=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+LockPersonality=yes
+DevicePolicy=closed
+
+[Install]
+WantedBy=multi-user.target

--- a/src/chia_log/parsers/block_parser.py
+++ b/src/chia_log/parsers/block_parser.py
@@ -27,7 +27,7 @@ class BlockParser:
     def __init__(self):
         logging.info("Enabled parser for block found stats.")
         self._regex = re.compile(
-            r"([0-9:.]*) full_node (?:src|chia).full_node.full_node\s*: INFO\s* ((?:🍀|.)\s* Farmed unfinished_block)"
+            r"([0-9:.]*) full_node (?:src|chia).full_node.full_node\s*: INFO\s* ((?:🍀 ️|.)\s*Farmed unfinished_block)"
         )
 
     def parse(self, logs: str) -> List[BlockMessage]:

--- a/src/notifier/__init__.py
+++ b/src/notifier/__init__.py
@@ -29,6 +29,8 @@ class EventType(Enum):
     KEEPALIVE = 0
     USER = 1
     DAILY_STATS = 2
+    PLOTDECREASE = 3
+    PLOTINCREASE = 4
 
 
 class EventService(Enum):
@@ -67,12 +69,17 @@ class Notifier(ABC):
 
         daily_stats = config.get("daily_stats", False)
         wallet_events = config.get("wallet_events", False)
-
+        decreasing_plot_events = config.get("decreasing_plot_events", False)
+        increasing_plot_events = config.get("increasing_plot_events", False)
         if daily_stats:
             self._notification_types.append(EventType.DAILY_STATS)
             self._notification_services.append(EventService.DAILY)
         if wallet_events:
             self._notification_services.append(EventService.WALLET)
+        if decreasing_plot_events:
+            self._notification_types.append(EventType.PLOTDECREASE)
+        if increasing_plot_events:
+            self._notification_types.append(EventType.PLOTINCREASE)
 
     def get_title_for_event(self, event):
         icon = ""

--- a/src/notifier/ifttt_notifier.py
+++ b/src/notifier/ifttt_notifier.py
@@ -1,0 +1,45 @@
+# std
+import http.client
+import logging
+import json
+import urllib.parse
+from typing import List
+
+# project
+from . import Notifier, Event
+
+
+class IftttNotifier(Notifier):
+    def __init__(self, title_prefix: str, config: dict):
+        logging.info("Initializing Ifttt notifier.")
+        super().__init__(title_prefix, config)
+        try:
+            credentials = config["credentials"]
+            self.token = credentials["api_token"]
+            self.webhook_name = credentials["webhook_name"]
+        except KeyError as key:
+            logging.error(f"Invalid config.yaml. Missing key: {key}")
+
+    def send_events_to_user(self, events: List[Event]) -> bool:
+        errors = False
+        for event in events:
+            if event.type in self._notification_types and event.service in self._notification_services:
+                conn = http.client.HTTPSConnection("maker.ifttt.com:443", timeout=self._conn_timeout_seconds)
+                request_body = json.dumps({"Message": event.message, "Title": self.get_title_for_event(event)})
+                conn.request(
+                    "POST",
+                    f"/trigger/{self.webhook_name}/json/with/key/{self.token}",
+                    request_body,
+                    headers={
+                        "Content-Type": "application/json",
+                        "Accept": "application/json",
+                        "API-Key": f"{self.token}",
+                    },
+                )
+                response = conn.getresponse()
+                if response.getcode() != 200:
+                    logging.warning(f"Problem sending event to user, code: {response.getcode()}")
+                    errors = True
+                conn.close()
+
+        return not errors

--- a/src/notifier/notify_manager.py
+++ b/src/notifier/notify_manager.py
@@ -9,6 +9,7 @@ from .grafana_notifier import GrafanaNotifier
 from .keep_alive_monitor import KeepAliveMonitor
 from .mqtt_notifier import MqttNotifier
 from .pushover_notifier import PushoverNotifier
+from .pushcut_notifier import PushcutNotifier
 from .script_notifier import ScriptNotifier
 from .smtp_notifier import SMTPNotifier
 from .telegram_notifier import TelegramNotifier
@@ -34,6 +35,7 @@ class NotifyManager:
     def _initialize_notifiers(self):
         key_notifier_mapping = {
             "pushover": PushoverNotifier,
+            "pushcut": PushcutNotifier,
             "script": ScriptNotifier,
             "telegram": TelegramNotifier,
             "discord": DiscordNotifier,

--- a/src/notifier/notify_manager.py
+++ b/src/notifier/notify_manager.py
@@ -15,6 +15,7 @@ from .smtp_notifier import SMTPNotifier
 from .telegram_notifier import TelegramNotifier
 from .discord_notifier import DiscordNotifier
 from .slack_notifier import SlackNotifier
+from .ifttt_notifier import IftttNotifier
 from src.config import Config
 
 
@@ -43,6 +44,7 @@ class NotifyManager:
             "slack": SlackNotifier,
             "mqtt": MqttNotifier,
             "grafana": GrafanaNotifier,
+            "ifttt": IftttNotifier,
         }
         for key in self._config.keys():
             if key not in key_notifier_mapping.keys():

--- a/src/notifier/pushcut_notifier.py
+++ b/src/notifier/pushcut_notifier.py
@@ -1,0 +1,45 @@
+# std
+import http.client
+import logging
+import json
+import urllib.parse
+from typing import List
+
+# project
+from . import Notifier, Event
+
+
+class PushcutNotifier(Notifier):
+    def __init__(self, title_prefix: str, config: dict):
+        logging.info("Initializing PushCut notifier.")
+        super().__init__(title_prefix, config)
+        try:
+            credentials = config["credentials"]
+            self.token = credentials["api_token"]
+            self.notification_name = credentials["notification_name"]
+        except KeyError as key:
+            logging.error(f"Invalid config.yaml. Missing key: {key}")
+
+    def send_events_to_user(self, events: List[Event]) -> bool:
+        errors = False
+        for event in events:
+            if event.type in self._notification_types and event.service in self._notification_services:
+                conn = http.client.HTTPSConnection("api.pushcut.io:443", timeout=self._conn_timeout_seconds)
+                request_body = json.dumps({"text": event.message, "title": self.get_title_for_event(event)})
+                conn.request(
+                    "POST",
+                    f"/v1/notifications/{self.notification_name}",
+                    request_body,
+                    headers={
+                        "Content-Type": "application/json",
+                        "Accept": "application/json",
+                        "API-Key": f"{self.token}",
+                    },
+                )
+                response = conn.getresponse()
+                if response.getcode() != 200:
+                    logging.warning(f"Problem sending event to user, code: {response.getcode()}")
+                    errors = True
+                conn.close()
+
+        return not errors

--- a/tests/chia_log/handlers/test_block_found_handler.py
+++ b/tests/chia_log/handlers/test_block_found_handler.py
@@ -1,0 +1,30 @@
+# std
+import unittest
+from pathlib import Path
+
+# project
+from src.chia_log.handlers import block_handler
+from src.notifier import EventType, EventService, EventPriority
+
+
+class TestBlockFoundHandler(unittest.TestCase):
+    def setUp(self) -> None:
+        self.handler = block_handler.BlockHandler()
+        self.example_logs_path = Path(__file__).resolve().parents[1] / "logs/block_found"
+
+    def testNominal(self):
+        with open(self.example_logs_path / "nominal.txt", encoding="UTF-8") as f:
+            logs = f.readlines()
+
+        expected_number_events = [1, 0]
+        for log, number_events in zip(logs, expected_number_events):
+            events = self.handler.handle(log)
+            self.assertEqual(len(events), number_events, "Un-expected number of events")
+            if number_events == 1:
+                self.assertEqual(events[0].type, EventType.USER, "Unexpected event type")
+                self.assertEqual(events[0].priority, EventPriority.LOW, "Unexpected priority")
+                self.assertEqual(events[0].service, EventService.FULL_NODE, "Unexpected service")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/chia_log/logs/block_found/nominal.txt
+++ b/tests/chia_log/logs/block_found/nominal.txt
@@ -1,0 +1,2 @@
+21:09:51.795 full_node chia.full_node.full_node: INFO     🍀 Farmed unfinished_block a29012c891bf8d764e66605ff3c5b9b12b125d528f3c530b8c68bf5c8b17d4d0, SP: 49, validation time: 0.06956624984741211, cost: 159432740
+23:19:13.564 full_node chia.full_node.full_node: INFO     Added unfinished_block 5ee48d91aabf8ba33eda4b67076e1348e64a6059995b25b4e1d0de77e3a5c18e, not farmed by us, SP: 5 farmer response time: 8.495556116104126, Pool pk xch189rpsfgve6d7rcm4aamgur5munpzfaaca89jcfdjczfjhnvjzz8qw5k3ru, validation time: 0.18387579917907715, cost: 560859505, percent full: 5.099%

--- a/tests/chia_log/logs/harvester_activity/plots_increased.txt
+++ b/tests/chia_log/logs/harvester_activity/plots_increased.txt
@@ -1,0 +1,5 @@
+10:39:36.535 harvester chia.harvester.harvester: INFO     0 plots were eligible for farming e25et6cb36... Found 0 proofs. Time: 0.55515 s. Total 40 plots
+10:39:45.931 harvester chia.harvester.harvester: INFO     1 plots were eligible for farming e25et6cb36... Found 0 proofs. Time: 1.05515 s. Total 41 plots
+10:39:54.412 harvester chia.harvester.harvester: INFO     2 plots were eligible for farming e25et6cb36... Found 0 proofs. Time: 0.23412 s. Total 42 plots
+10:40:03.331 harvester chia.harvester.harvester: INFO     3 plots were eligible for farming e25et6cb36... Found 0 proofs. Time: 0.12348 s. Total 45 plots
+10:40:12.112 harvester chia.harvester.harvester: INFO     0 plots were eligible for farming e25et6cb36... Found 0 proofs. Time: 0.34952 s. Total 45 plots

--- a/tests/chia_log/parsers/test_block_found_parser.py
+++ b/tests/chia_log/parsers/test_block_found_parser.py
@@ -1,0 +1,33 @@
+# std
+import unittest
+from pathlib import Path
+
+# project
+from src.chia_log.parsers import block_parser
+
+
+class TestBlockFoundParser(unittest.TestCase):
+    def setUp(self) -> None:
+        self.parser = block_parser.BlockParser()
+        self.example_logs_path = Path(__file__).resolve().parents[1] / "logs/block_found"
+        with open(self.example_logs_path / "nominal.txt", encoding="UTF-8") as f:
+            self.nominal_logs = f.read()
+
+    def tearDown(self) -> None:
+        pass
+
+    def testBasicParsing(self):
+        for logs in [self.nominal_logs]:
+            activity_messages = self.parser.parse(logs)
+            self.assertNotEqual(len(activity_messages), 0, "No log messages found")
+
+            expected_eligible_block_counts = [1, 0]
+            for msg, found in zip(
+                activity_messages,
+                expected_eligible_block_counts,
+            ):
+                self.assertEqual(msg.blocks_count, found, "Found block count don't match")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/notifier/test_discord_notifier.py
+++ b/tests/notifier/test_discord_notifier.py
@@ -17,6 +17,8 @@ class TestDiscordNotifier(unittest.TestCase):
                 "enable": True,
                 "daily_stats": True,
                 "wallet_events": True,
+                "decreasing_plot_events": True,
+                "increasing_plot_events": True,
                 "credentials": {"webhook_url": webhook_url},
             },
         )

--- a/tests/notifier/test_ifttt_notifier.py
+++ b/tests/notifier/test_ifttt_notifier.py
@@ -1,0 +1,106 @@
+# std
+import os
+import unittest
+
+# project
+from src.notifier import Event, EventType, EventPriority, EventService
+from src.notifier.ifttt_notifier import IftttNotifier
+from .dummy_events import DummyEvents
+
+
+class TestIftttNotifier(unittest.TestCase):
+    def setUp(self) -> None:
+        self.api_token = os.getenv("IFTTT_API_TOKEN")
+        self.webhook_name = os.getenv("IFTTT_WEBHOOK_NAME")
+        self.assertIsNotNone(self.api_token, "You must export IFTTT_API_TOKEN as env variable")
+        self.assertIsNotNone(self.webhook_name, "You must export IFTTT_WEBHOOK_NAME as env variable")
+        self.notifier = IftttNotifier(
+            title_prefix="Test",
+            config={
+                "enable": True,
+                "daily_stats": True,
+                "wallet_events": True,
+                "credentials": {"api_token": self.api_token, "webhook_name": self.webhook_name},
+            },
+        )
+
+    @unittest.skipUnless(os.getenv("IFTTT_API_TOKEN"), "Run only if token available")
+    def testLowPriorityNotifications(self):
+        success = self.notifier.send_events_to_user(events=DummyEvents.get_low_priority_events())
+        self.assertTrue(success)
+
+    @unittest.skipUnless(os.getenv("IFTTT_API_TOKEN"), "Run only if token available")
+    def testNormalPriorityNotifications(self):
+        success = self.notifier.send_events_to_user(events=DummyEvents.get_normal_priority_events())
+        self.assertTrue(success)
+
+    @unittest.skipUnless(os.getenv("IFTTT_API_TOKEN"), "Run only if token available")
+    def testHighPriorityNotifications(self):
+        success = self.notifier.send_events_to_user(events=DummyEvents.get_high_priority_events())
+        self.assertTrue(success)
+
+    @unittest.skipUnless(os.getenv("SHOWCASE_NOTIFICATIONS"), "Only for showcasing")
+    def testShowcaseGoodNotifications(self):
+        notifiers = [
+            IftttNotifier(
+                title_prefix="Harvester 1",
+                config={"enable": True, "api_token": self.api_token, "webhook_name": self.webhook_name},
+            ),
+            IftttNotifier(
+                title_prefix="Harvester 2",
+                config={"enable": True, "api_token": self.api_token, "webhook_name": self.webhook_name},
+            ),
+            IftttNotifier(
+                title_prefix="Harvester 3",
+                config={"enable": True, "api_token": self.api_token, "webhook_name": self.webhook_name},
+            ),
+        ]
+        found_proof_event = Event(
+            type=EventType.USER,
+            priority=EventPriority.LOW,
+            service=EventService.HARVESTER,
+            message="Found 1 proof(s)!",
+        )
+        for notifier in notifiers:
+            success = notifier.send_events_to_user(events=[found_proof_event])
+            self.assertTrue(success)
+
+    @unittest.skipUnless(os.getenv("SHOWCASE_NOTIFICATIONS"), "Only for showcasing")
+    def testShowcaseBadNotifications(self):
+        notifiers = [
+            IftttNotifier(
+                title_prefix="Harvester 1",
+                config={"enable": True, "api_token": self.api_token, "webhook_name": self.webhook_name},
+            ),
+            IftttNotifier(
+                title_prefix="Harvester 2",
+                config={"enable": True, "api_token": self.api_token, "webhook_name": self.webhook_name},
+            ),
+            IftttNotifier(
+                title_prefix="Harvester 3",
+                config={"enable": True, "api_token": self.api_token, "webhook_name": self.webhook_name},
+            ),
+        ]
+        disconnected_hdd = Event(
+            type=EventType.USER,
+            priority=EventPriority.HIGH,
+            service=EventService.HARVESTER,
+            message="Disconnected HDD? The total plot count decreased from 101 to 42.",
+        )
+        network_issues = Event(
+            type=EventType.USER,
+            priority=EventPriority.NORMAL,
+            service=EventService.HARVESTER,
+            message="Experiencing networking issues? Harvester did not participate in any "
+            "challenge for 120 seconds. It's now working again.",
+        )
+        offline = Event(
+            type=EventType.USER,
+            priority=EventPriority.HIGH,
+            service=EventService.HARVESTER,
+            message="Your harvester appears to be offline! No events for the past 712 seconds.",
+        )
+        events = [disconnected_hdd, offline, network_issues]
+        for notifier, event in zip(notifiers, events):
+            success = notifier.send_events_to_user(events=[event])
+            self.assertTrue(success)

--- a/tests/notifier/test_ifttt_notifier.py
+++ b/tests/notifier/test_ifttt_notifier.py
@@ -20,6 +20,8 @@ class TestIftttNotifier(unittest.TestCase):
                 "enable": True,
                 "daily_stats": True,
                 "wallet_events": True,
+                "decreasing_plot_events": True,
+                "increasing_plot_events": True,
                 "credentials": {"api_token": self.api_token, "webhook_name": self.webhook_name},
             },
         )
@@ -87,6 +89,12 @@ class TestIftttNotifier(unittest.TestCase):
             service=EventService.HARVESTER,
             message="Disconnected HDD? The total plot count decreased from 101 to 42.",
         )
+        connected_hdd = Event(
+            type=EventType.PLOTINCREASE,
+            priority=EventPriority.HIGH,
+            service=EventService.HARVESTER,
+            message="Connected HDD? The total plot count increased from 0 to 42.",
+        )
         network_issues = Event(
             type=EventType.USER,
             priority=EventPriority.NORMAL,
@@ -100,7 +108,7 @@ class TestIftttNotifier(unittest.TestCase):
             service=EventService.HARVESTER,
             message="Your harvester appears to be offline! No events for the past 712 seconds.",
         )
-        events = [disconnected_hdd, offline, network_issues]
+        events = [disconnected_hdd, connected_hdd, offline, network_issues]
         for notifier, event in zip(notifiers, events):
             success = notifier.send_events_to_user(events=[event])
             self.assertTrue(success)

--- a/tests/notifier/test_mqtt_notifier.py
+++ b/tests/notifier/test_mqtt_notifier.py
@@ -31,6 +31,8 @@ class TestMqttNotifier(unittest.TestCase):
                 "enable": True,
                 "daily_stats": True,
                 "wallet_events": True,
+                "decreasing_plot_events": True,
+                "increasing_plot_events": True,
                 "topic": topic,
                 "qos": qos,
                 "retain": retain,

--- a/tests/notifier/test_pushcut_notifier.py
+++ b/tests/notifier/test_pushcut_notifier.py
@@ -1,0 +1,106 @@
+# std
+import os
+import unittest
+
+# project
+from src.notifier import Event, EventType, EventPriority, EventService
+from src.notifier.pushcut_notifier import PushcutNotifier
+from .dummy_events import DummyEvents
+
+
+class TestPushcutNotifier(unittest.TestCase):
+    def setUp(self) -> None:
+        self.api_token = os.getenv("PUSHCUT_API_TOKEN")
+        self.notification_name = os.getenv("PUSHCUT_NOTIFICATION_NAME")
+        self.assertIsNotNone(self.api_token, "You must export PUSHCUT_API_TOKEN as env variable")
+        self.assertIsNotNone(self.notification_name, "You must export PUSHCUT_NOTIFICATION_NAME as env variable")
+        self.notifier = PushcutNotifier(
+            title_prefix="Test",
+            config={
+                "enable": True,
+                "daily_stats": True,
+                "wallet_events": True,
+                "credentials": {"api_token": self.api_token, "notification_name": self.notification_name},
+            },
+        )
+
+    @unittest.skipUnless(os.getenv("PUSHCUT_API_TOKEN"), "Run only if token available")
+    def testLowPriorityNotifications(self):
+        success = self.notifier.send_events_to_user(events=DummyEvents.get_low_priority_events())
+        self.assertTrue(success)
+
+    @unittest.skipUnless(os.getenv("PUSHCUT_API_TOKEN"), "Run only if token available")
+    def testNormalPriorityNotifications(self):
+        success = self.notifier.send_events_to_user(events=DummyEvents.get_normal_priority_events())
+        self.assertTrue(success)
+
+    @unittest.skipUnless(os.getenv("PUSHCUT_API_TOKEN"), "Run only if token available")
+    def testHighPriorityNotifications(self):
+        success = self.notifier.send_events_to_user(events=DummyEvents.get_high_priority_events())
+        self.assertTrue(success)
+
+    @unittest.skipUnless(os.getenv("SHOWCASE_NOTIFICATIONS"), "Only for showcasing")
+    def testShowcaseGoodNotifications(self):
+        notifiers = [
+            PushcutNotifier(
+                title_prefix="Harvester 1",
+                config={"enable": True, "api_token": self.api_token, "notification_name": self.notification_name},
+            ),
+            PushcutNotifier(
+                title_prefix="Harvester 2",
+                config={"enable": True, "api_token": self.api_token, "notification_name": self.notification_name},
+            ),
+            PushcutNotifier(
+                title_prefix="Harvester 3",
+                config={"enable": True, "api_token": self.api_token, "notification_name": self.notification_name},
+            ),
+        ]
+        found_proof_event = Event(
+            type=EventType.USER,
+            priority=EventPriority.LOW,
+            service=EventService.HARVESTER,
+            message="Found 1 proof(s)!",
+        )
+        for notifier in notifiers:
+            success = notifier.send_events_to_user(events=[found_proof_event])
+            self.assertTrue(success)
+
+    @unittest.skipUnless(os.getenv("SHOWCASE_NOTIFICATIONS"), "Only for showcasing")
+    def testShowcaseBadNotifications(self):
+        notifiers = [
+            PushcutNotifier(
+                title_prefix="Harvester 1",
+                config={"enable": True, "api_token": self.api_token, "notification_name": self.notification_name},
+            ),
+            PushcutNotifier(
+                title_prefix="Harvester 2",
+                config={"enable": True, "api_token": self.api_token, "notification_name": self.notification_name},
+            ),
+            PushcutNotifier(
+                title_prefix="Harvester 3",
+                config={"enable": True, "api_token": self.api_token, "notification_name": self.notification_name},
+            ),
+        ]
+        disconnected_hdd = Event(
+            type=EventType.USER,
+            priority=EventPriority.HIGH,
+            service=EventService.HARVESTER,
+            message="Disconnected HDD? The total plot count decreased from 101 to 42.",
+        )
+        network_issues = Event(
+            type=EventType.USER,
+            priority=EventPriority.NORMAL,
+            service=EventService.HARVESTER,
+            message="Experiencing networking issues? Harvester did not participate in any "
+            "challenge for 120 seconds. It's now working again.",
+        )
+        offline = Event(
+            type=EventType.USER,
+            priority=EventPriority.HIGH,
+            service=EventService.HARVESTER,
+            message="Your harvester appears to be offline! No events for the past 712 seconds.",
+        )
+        events = [disconnected_hdd, offline, network_issues]
+        for notifier, event in zip(notifiers, events):
+            success = notifier.send_events_to_user(events=[event])
+            self.assertTrue(success)

--- a/tests/notifier/test_pushcut_notifier.py
+++ b/tests/notifier/test_pushcut_notifier.py
@@ -87,6 +87,12 @@ class TestPushcutNotifier(unittest.TestCase):
             service=EventService.HARVESTER,
             message="Disconnected HDD? The total plot count decreased from 101 to 42.",
         )
+        connected_hdd = Event(
+            type=EventType.PLOTINCREASE,
+            priority=EventPriority.HIGH,
+            service=EventService.HARVESTER,
+            message="Connected HDD? The total plot count increased from 0 to 42.",
+        )
         network_issues = Event(
             type=EventType.USER,
             priority=EventPriority.NORMAL,
@@ -100,7 +106,7 @@ class TestPushcutNotifier(unittest.TestCase):
             service=EventService.HARVESTER,
             message="Your harvester appears to be offline! No events for the past 712 seconds.",
         )
-        events = [disconnected_hdd, offline, network_issues]
+        events = [disconnected_hdd, connected_hdd, offline, network_issues]
         for notifier, event in zip(notifiers, events):
             success = notifier.send_events_to_user(events=[event])
             self.assertTrue(success)

--- a/tests/notifier/test_pushover_notifier.py
+++ b/tests/notifier/test_pushover_notifier.py
@@ -20,6 +20,8 @@ class TestPushoverNotifier(unittest.TestCase):
                 "enable": True,
                 "daily_stats": True,
                 "wallet_events": True,
+                "decreasing_plot_events": True,
+                "increasing_plot_events": True,
                 "credentials": {"api_token": self.api_token, "user_key": self.user_key},
             },
         )
@@ -82,10 +84,16 @@ class TestPushoverNotifier(unittest.TestCase):
             ),
         ]
         disconnected_hdd = Event(
-            type=EventType.USER,
+            type=EventType.PLOTDECREASE,
             priority=EventPriority.HIGH,
             service=EventService.HARVESTER,
             message="Disconnected HDD? The total plot count decreased from 101 to 42.",
+        )
+        connected_hdd = Event(
+            type=EventType.PLOTINCREASE,
+            priority=EventPriority.HIGH,
+            service=EventService.HARVESTER,
+            message="Connected HDD? The total plot count increased from 0 to 42.",
         )
         network_issues = Event(
             type=EventType.USER,
@@ -100,7 +108,7 @@ class TestPushoverNotifier(unittest.TestCase):
             service=EventService.HARVESTER,
             message="Your harvester appears to be offline! No events for the past 712 seconds.",
         )
-        events = [disconnected_hdd, offline, network_issues]
+        events = [disconnected_hdd, connected_hdd, offline, network_issues]
         for notifier, event in zip(notifiers, events):
             success = notifier.send_events_to_user(events=[event])
             self.assertTrue(success)

--- a/tests/notifier/test_script_notifier.py
+++ b/tests/notifier/test_script_notifier.py
@@ -10,7 +10,14 @@ class TestScriptNotifier(unittest.TestCase):
     def setUp(self) -> None:
         self.notifier = ScriptNotifier(
             title_prefix="Test",
-            config={"enable": True, "daily_stats": True, "wallet_events": True, "script_path": "tests/test_script.sh"},
+            config={
+                "enable": True,
+                "daily_stats": True,
+                "wallet_events": True,
+                "decreasing_plot_events": True,
+                "increasing_plot_events": True,
+                "script_path": "tests/test_script.sh",
+            },
         )
 
     def testLowPriorityNotifications(self):

--- a/tests/notifier/test_slack_notifier.py
+++ b/tests/notifier/test_slack_notifier.py
@@ -17,6 +17,8 @@ class TestSlackNotifier(unittest.TestCase):
                 "enable": True,
                 "daily_stats": True,
                 "wallet_events": True,
+                "decreasing_plot_events": True,
+                "increasing_plot_events": True,
                 "credentials": {"webhook_url": webhook_url},
             },
         )

--- a/tests/notifier/test_smtp_notifier.py
+++ b/tests/notifier/test_smtp_notifier.py
@@ -30,6 +30,8 @@ class TestSMTPNotifier(unittest.TestCase):
                 "enable": True,
                 "daily_stats": True,
                 "wallet_events": True,
+                "decreasing_plot_events": True,
+                "increasing_plot_events": True,
                 "credentials": {
                     "sender": sender,
                     "sender_name": sender_name,

--- a/tests/notifier/test_telegram_notifier.py
+++ b/tests/notifier/test_telegram_notifier.py
@@ -19,6 +19,8 @@ class TestTelegramNotifier(unittest.TestCase):
                 "enable": True,
                 "daily_stats": True,
                 "wallet_events": True,
+                "decreasing_plot_events": True,
+                "increasing_plot_events": True,
                 "credentials": {"bot_token": bot_token, "chat_id": chat_id},
             },
         )


### PR DESCRIPTION
Should resolve #312, relates to discussion #51. Attempts to sandbox chiadog as a systemd service, and safeguard any sensitive chia files in `.chia/mainnet` that we don't need access to. 

* Add a scripts/linux/chiadog.service systemd example that attempts to run chiadog in a more isolated environment. Create a new limited user each run (making much of the filesystem readonly), and set `.chia/mainnet` folders other than `log` to inaccessible.
* Move the offset file - previously, the `debug.log.offset` file was kept in the chiadog directory, but when running in a read only filesystem we can't write there. Create a temporary directory when running, and store the offset file there. This also means we no longer need to delete the offset file on startup.

A good way to test this is to switch out the `ExecStart` for an `ls -lh .chia/mainnet` and see what files are accessible inside the environment, or try to run `venv/bin/chia wallet show` inside and make sure it fails. Ideally I'd like to have chiadog show a warning when it starts up if it's able to access configuration directories, but I figure that could be added in another PR. 

There are a bunch of different strategies in systemd for setting this up, I went with what seems to be the most compatible version (compatible with systemd 235, which I believe is available in Ubuntu 18), explicitly declaring `InaccessiblePaths`. The other way, using `TemporarilyFilesystem` to block everything out and binding the one file we need, is maybe a bit more elegant, but needs at least systemd 238 (around Ubuntu 20). Since it's not possible to say "make everything except the logs folder inaccessible" however (declaring `.chia` as inaccessible makes all child directories inaccessible and can't be overridden by other directives), we need to remember to add any new paths if new versions of chia add additional directories we don't want access to. 