### PR TITLE
Sandboxed systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,16 +196,19 @@ nohup python3 -u main.py --config config.yaml > output.log 2>&1 &
 To stop chiadog, you can find the Process ID (PID) via `ps aux | grep main.py` and then softly interrupt the process
 with `kill -SIGINT <pid_here>`.
 
+You can also run chiadog as a sandboxed systemd service.
+
 ## Running `chiadog` in sandboxed environment
 
-We're in the early stages of exploring the best way to provide easy to setup sandboxed environment where the `chiadog`
-process is completely isolated from potentially accessing your private keys. Contributions in that direction are very
-welcome. Meanwhile you can check out @ajacobson repository
-for [chiadog-docker](https://github.com/ajacobson/chiadog-docker).
+We're still exploring the best way to provide easy to setup sandboxed environment where the `chiadog` process is
+completely isolated from potentially accessing your private keys. Contributions in that direction are very welcome.
 
-Alternatively, [as suggested here](https://github.com/martomi/chiadog/issues/24) you can run `chiadog` from a unix user
-with limited permissions.
-
+* There is an example [systemd service](scripts/linux/chiadog.service) you can configure which runs chiadog as a limited
+user and blocks access to key chia locations.
+* Alternatively, [as suggested here](https://github.com/martomi/chiadog/issues/24) you can run `chiadog` from a unix
+user with limited permissions.
+* For running in docker, you can check out @ajacobson repository for
+[chiadog-docker](https://github.com/ajacobson/chiadog-docker).
 # Contributing
 
 Contributions are always welcome! Please refer to [CONTRIBUTING](CONTRIBUTING.md) documentation.

--- a/main.py
+++ b/main.py
@@ -53,12 +53,6 @@ def init(config:Config):
 
     logging.info(f"Starting Chiadog ({version()})")
 
-    # Remove the Pygtail offset file if it exists
-    # Fixes a bug where hard reboot corrupts the offset file
-    offset = Config.get_log_offset_path()
-    if offset.exists():
-        offset.unlink()
-
     # Create log consumer based on provided configuration
     chia_logs_config = config.get_chia_logs_config()
     log_consumer = create_log_consumer_from_config(chia_logs_config)

--- a/scripts/linux/chiadog.service
+++ b/scripts/linux/chiadog.service
@@ -1,0 +1,81 @@
+# Runs chiadog as a limited service
+#
+# It requires at least systemd 235 for the sandboxing features,
+# although it will run without them on earlier versions.
+#
+# Replace {home-path} and {path-to-chiadog} with your absolute
+# paths before copying it to your systemd directory -
+#
+# /etc/systemd/system/chiadog.service
+#
+# It can then be run by reloading services and starting it -
+#
+# > sudo systemctl daemon-reload
+# > sudo systemctl start chiadog
+#
+# You can watch the log output by using -
+#
+# > sudo journalctl -u chiadog -f
+#
+# You can also review the security policy by using -
+#
+# > systemd-analyze security chiadog.service
+#
+
+[Unit]
+Description=chiadog
+Wants=network-online.target
+After=network.target network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+
+# Create a new user with limited access each time the service is started
+DynamicUser=yes
+
+# Hide any important chia files (such as the wallet keys)
+#
+# It's important to update these paths as chia adds any new directories we want to hide,
+# as there's no way to hide everything *except* for log/debug.log (without using newer,
+# less supported temporary filesystem features).
+#
+# You could also configure chia to place the log file outside of ~/.chia, and then block
+# the entire ~./chia directory if you prefer.
+#
+InaccessiblePaths=/{home-path}/.chia/mainnet/config /{home-path}/.chia/mainnet/wallet /{home-path}/.chia/mainnet/db /{home-path}/.chia/mainnet/run
+
+# Absolute path to chiadog such as /home/my-user/chiadog
+WorkingDirectory=/{path-to-chiadog}
+
+# Using the python from venv bin will activate the environment automatically  
+ExecStart=/{path-to-chiadog}/venv/bin/python -u main.py --config config.yaml
+
+Restart=always
+RestartSec=1
+
+# Allow chiadog to shut down smoothly
+KillSignal=SIGINT
+
+# Lock down the service further
+# See https://www.digitalocean.com/community/tutorials/how-to-sandbox-processes-with-systemd-on-ubuntu-20-04
+# as well as https://gist.github.com/ageis/f5595e59b1cddb1513d1b425a323db04
+SystemCallFilter=@system-service
+NoNewPrivileges=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+MemoryDenyWriteExecute=yes
+RestrictRealtime=yes
+PrivateDevices=yes
+ProtectHostname=yes
+PrivateUsers=yes
+RestrictNamespaces=yes
+CapabilityBoundingSet=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+LockPersonality=yes
+DevicePolicy=closed
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Should resolve #312, relates to discussion #51. Attempts to sandbox chiadog as a systemd service, and safeguard any sensitive chia files in `.chia/mainnet` that we don't need access to. 

* Add a scripts/linux/chiadog.service systemd example that attempts to run chiadog in a more isolated environment. Create a new limited user each run (making much of the filesystem readonly), and set `.chia/mainnet` folders other than `log` to inaccessible.
* Move the offset file - previously, the `debug.log.offset` file was kept in the chiadog directory, but when running in a read only filesystem we can't write there. Create a temporary directory when running, and store the offset file there. This also means we no longer need to delete the offset file on startup.

A good way to test this is to switch out the `ExecStart` for an `ls -lh .chia/mainnet` and see what files are accessible inside the environment, or try to run `venv/bin/chia wallet show` inside and make sure it fails. Ideally I'd like to have chiadog show a warning when it starts up if it's able to access configuration directories, but I figure that could be added in another PR. 

There are a bunch of different strategies in systemd for setting this up, I went with what seems to be the most compatible version (compatible with systemd 235, which I believe is available in Ubuntu 18), explicitly declaring `InaccessiblePaths`. The other way, using `TemporarilyFilesystem` to block everything out and binding the one file we need, is maybe a bit more elegant, but needs at least systemd 238 (around Ubuntu 20). Since it's not possible to say "make everything except the logs folder inaccessible" however (declaring `.chia` as inaccessible makes all child directories inaccessible and can't be overridden by other directives), we need to remember to add any new paths if new versions of chia add additional directories we don't want access to. 