### PR TITLE
Add ~/.chia_keys to list of InaccessiblePaths in systemd

### DIFF
--- a/scripts/linux/chiadog.service
+++ b/scripts/linux/chiadog.service
@@ -43,7 +43,7 @@ DynamicUser=yes
 # You could also configure chia to place the log file outside of ~/.chia, and then block
 # the entire ~./chia directory if you prefer.
 #
-InaccessiblePaths=/{home-path}/.chia/mainnet/config /{home-path}/.chia/mainnet/wallet /{home-path}/.chia/mainnet/db /{home-path}/.chia/mainnet/run
+InaccessiblePaths=/{home-path}/.chia/mainnet/config /{home-path}/.chia/mainnet/wallet /{home-path}/.chia/mainnet/db /{home-path}/.chia/mainnet/run /{home-path}/.chia_keys
 
 # Absolute path to chiadog such as /home/my-user/chiadog
 WorkingDirectory=/{path-to-chiadog}


### PR DESCRIPTION
Update for #319 - Chia is [migrating their keyfiles](https://github.com/Chia-Network/chia-blockchain/wiki/Passphrase-Protected-Chia-Keys-and-Key-Storage-Migration) to `~/.chia_keys` (I was a version behind so I hadn't noticed - it appears existing keys will remain in `~/.chia/config`, but with fresh installs or new keys, they'll move to `chia_keys`). Block this folder from access in the systemd service.