### PR TITLE
Inhouse docker image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+*.yaml
+*.md
+docs
+Dockerfile
+scripts
+tests
+venv

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,55 @@
+name: Docker image
+
+on: push
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get the release channel
+        id: get_channel
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == 'refs/heads/main' ]]; then
+            echo ::set-output name=channel::"latest"
+            echo ::set-output name=version::${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::6}
+          elif [[ "$GITHUB_REF" == "refs/heads/"* ]]; then
+            echo ::set-output name=version::${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::6}
+          elif [[ "$GITHUB_REF" == "refs/tags/"* ]]; then
+            echo ::set-output name=channel::${GITHUB_REF/refs\/tags\//}
+          fi
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.get_channel.outputs.channel }}
+            type=raw,value=${{ steps.get_channel.outputs.version }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # secrets
-*.yaml
-*.yml
-!config-example.yaml
-!.github/**/*.yaml
-!.github/**/*.yml
+config.yaml
+config.*.yaml
 
 # pygtail offset
 debug.log.offset

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # secrets
-config.yaml
-config.*.yaml
+*.yaml
+*.yml
+!config-example.yaml
+!.github/**/*.yaml
+!.github/**/*.yml
 
 # pygtail offset
 debug.log.offset

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:latest
+
+ENV config_dir=/root/.chiadog/config.yaml
+ENV TZ=UTC
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y python3 bash ca-certificates git openssl python3-pip build-essential python3-dev python3.8-venv python3.8-distutils python-is-python3 tzdata
+
+RUN dpkg-reconfigure -f noninteractive tzdata
+
+RUN apt-get install -y libsodium-dev
+RUN SODIUM_INSTALL=system pip3 install pynacl
+
+COPY . /chiadog
+WORKDIR /chiadog
+RUN python3 -m venv venv \
+&& . ./venv/bin/activate \
+&& pip3 install -r requirements.txt
+
+
+ENTRYPOINT ["/chiadog/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,12 @@
-FROM ubuntu:latest
+FROM python:3.10-slim
 
-ENV config_dir=/root/.chiadog/config.yaml
+ENV CHIADOG_CONFIG_DIR=/root/.chiadog/config.yaml
 ENV TZ=UTC
-
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y python3 bash ca-certificates git openssl python3-pip build-essential python3-dev python3.8-venv python3.8-distutils python-is-python3 tzdata
-
-RUN dpkg-reconfigure -f noninteractive tzdata
-
-RUN apt-get install -y libsodium-dev
-RUN SODIUM_INSTALL=system pip3 install pynacl
 
 COPY . /chiadog
 WORKDIR /chiadog
 RUN python3 -m venv venv \
 && . ./venv/bin/activate \
 && pip3 install -r requirements.txt
-
 
 ENTRYPOINT ["/chiadog/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ -z "${TZ}" ]]; then
+  echo "Setting timezone to ${TZ}"
+  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+fi
+
+cd /chiadog
+
+. ./venv/bin/activate
+
+python3 main.py --config ${config_dir}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,5 @@
-#!/bin/bash
-
-if [[ -z "${TZ}" ]]; then
-  echo "Setting timezone to ${TZ}"
-  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-fi
+#!/bin/sh
 
 cd /chiadog
-
 . ./venv/bin/activate
-
-python3 main.py --config ${config_dir}
+python main.py --config ${CHIADOG_CONFIG_DIR}


### PR DESCRIPTION
This hugely builds on the work by @ajacobson (https://github.com/ajacobson/chiadog-docker) and no disrespect is intended.

Proposing merge to `main` instead of `dev` since this does not in any way modify how Chiadog works and will then enable images to be built for any and all branches regardless of when dev is merged to main.

## Major benefits of inhousing:
  - Can easily build any state of the repo regardless of branch or
      mid-development into a functional image without mucking about with an
      external repo. Doing other chiadog development made me frustrated enough to also fix this. :-)
  - Faster builds when the source code is already present without an extra clone
  - Automated Docker image builds into the free GitHub image repository. Official images triggered by official tags & releases, but also dev images any any other branch provide repeatable and traceable pinning of images.
    
## Minor fixes added as well:
  - entrypoint.sh was missing a shebang
   - Simplified entrypoint running now that the script has a proper shebang
   - Simplified logic by switching WORKDIR earlier
   - Add a .dockerignore file to prune dirty state and useless weight from
      the container.
    
## Does not include:
  - Any documentation. Docker is an advanced option in any case but this
      should be added as a followup.
 