### PR TITLE
Docker: Simplify & build only for releases

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,6 +1,8 @@
 name: Docker image
 
-on: push
+on:
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -15,29 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Get the release channel
-        id: get_channel
-        shell: bash
-        run: |
-          if [[ "$GITHUB_REF" == 'refs/heads/main' ]]; then
-            echo ::set-output name=channel::"latest"
-            echo ::set-output name=version::${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::6}
-          elif [[ "$GITHUB_REF" == "refs/heads/"* ]]; then
-            echo ::set-output name=version::${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::6}
-          elif [[ "$GITHUB_REF" == "refs/tags/"* ]]; then
-            echo ::set-output name=channel::${GITHUB_REF/refs\/tags\//}
-          fi
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=${{ steps.get_channel.outputs.channel }}
-            type=raw,value=${{ steps.get_channel.outputs.version }}
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -45,6 +25,12 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.10-slim
 
+LABEL org.opencontainers.image.source="https://github.com/martomi/chiadog"
+
 ENV CHIADOG_CONFIG_DIR=/root/.chiadog/config.yaml
 ENV TZ=UTC
 


### PR DESCRIPTION
Currently it's getting build on every push and it fails to push for feature branches. Instead of fixing that, decided to enable it only for releases, since we don't know docker build on every push to a feature branch.

Also simplify to more minimal configuration.