### PR TITLE
Omit debug logging of zero mojo transactions.

### DIFF
--- a/src/chia_log/handlers/wallet_added_coin_handler.py
+++ b/src/chia_log/handlers/wallet_added_coin_handler.py
@@ -47,7 +47,7 @@ class WalletAddedCoinHandler(LogHandlerInterface):
                     message=f"Cha-ching! Just received {xch_string} XCH ☘️",
                 )
             )
-        else:
+        elif total_mojos != 0:
             logging.debug(
                 f"Filtering out chia coin message since the amount ${total_mojos} received is less than"
                 f"the configured transaction_amount: ${self.min_mojos_amount}"

--- a/src/notifier/keep_alive_monitor.py
+++ b/src/notifier/keep_alive_monitor.py
@@ -4,7 +4,7 @@ import urllib.request
 from datetime import datetime
 from threading import Thread
 from time import sleep
-from typing import List
+from typing import List, Optional
 
 # project
 from . import EventService, Event, EventType, EventPriority
@@ -24,7 +24,7 @@ class KeepAliveMonitor:
     receiving keep-alive ping events and can notify the user.
     """
 
-    def __init__(self, config: dict = None, thresholds: dict = None):
+    def __init__(self, config: Optional[dict] = None, thresholds: Optional[dict] = None):
         self._notify_manager = None
 
         self._last_keep_alive = {EventService.HARVESTER: datetime.now()}


### PR DESCRIPTION
Since the flow of transactions is constant, logging zero transactions makes debug logs very hard to read. Non-zero mojo transactions under the set limit are still debug logged.