### PR TITLE
Fix up the Grafana notifier so it's more standard and functions post config-revamp

### DIFF
--- a/src/default_config.yaml
+++ b/src/default_config.yaml
@@ -100,12 +100,12 @@ notifier:
       username: null
       password: null
   grafana:
-    enable: false
+    <<: *notifier_defaults
     credentials:
       base_url: null
       api_token: null
-      dashboard_id: -1
-      panel_id: -1
+      dashboard_id: null # default to global annotation
+      panel_id: null # default to global annotation
   ifttt:
     <<: *notifier_defaults
     credentials:

--- a/src/notifier/__init__.py
+++ b/src/notifier/__init__.py
@@ -7,8 +7,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List
 from enum import Enum
+import logging
 
 # lib
+import confuse
 from confuse import ConfigView
 
 
@@ -70,7 +72,10 @@ class Notifier(ABC):
         self._notification_types = [EventType.USER]
         self._notification_services = [EventService.HARVESTER, EventService.FARMER, EventService.FULL_NODE]
 
-        daily_stats = config["daily_stats"].get(bool)
+        try:
+            daily_stats = config["daily_stats"].get(bool)
+        except confuse.exceptions.NotFoundError:
+            logging.debug(f"Not initializing daily_stats for {__name__}, not supported")
         wallet_events = config["wallet_events"].get(bool)
         decreasing_plot_events = config["decreasing_plot_events"].get(bool)
         increasing_plot_events = config["increasing_plot_events"].get(bool)

--- a/src/notifier/grafana_notifier.py
+++ b/src/notifier/grafana_notifier.py
@@ -124,7 +124,6 @@ class GrafanaNotifier(Notifier):
     def _send_request(self, method: str, endpoint: ParseResult, payload: dict) -> HTTPResponse:
         request_body = json.dumps(payload)
         conn = self._get_connection(endpoint)
-
         conn.request(
             method=method,
             url=endpoint.path,

--- a/tests/notifier/test_grafana_notifier.py
+++ b/tests/notifier/test_grafana_notifier.py
@@ -20,6 +20,10 @@ class TestGrafanaNotifier(unittest.TestCase):
         self.config.set(
             {
                 "enable": True,
+                "daily_stats": False,
+                "wallet_events": False,
+                "decreasing_plot_events": True,
+                "increasing_plot_events": True,
                 "credentials": {
                     "base_url": base_url,
                     "api_token": api_token,


### PR DESCRIPTION
While not all options actually make sense for it, it's easier to provide them than special case just because no one would actually ever enable them.

NOTE: This does not mean the Grafana notifier actually supports any more events than it does right now. It probably should, but that's out of scope.

@pieterhelsen As the original author of the integration. I'm not actually managing to push the annotations to Grafana no matter how much I try, so could you check that I'm not accidentally changing anything critical here? For example, code comments lead me to believe null would default to global annotations, but `-1` is the example value given, so not sure what the truth there is. Also the test doesn't yet support defining those values.