### PR TITLE
Groundwork for keepalives for all services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@ LABEL org.opencontainers.image.source="https://github.com/martomi/chiadog"
 ENV CHIADOG_CONFIG_DIR=/root/.chiadog/config.yaml
 ENV TZ=UTC
 
-COPY . /chiadog
 WORKDIR /chiadog
+COPY requirements.txt /chiadog
 RUN python3 -m venv venv \
 && . ./venv/bin/activate \
 && pip3 install -r requirements.txt
+
+COPY . /chiadog
 
 ENTRYPOINT ["/chiadog/entrypoint.sh"]

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -27,6 +27,15 @@ chia_logs:
 keep_alive_monitor:
   enable_remote_ping: false
   ping_url: ''
+  # These thresholds determine how long a service can be unhealthy,
+  # before we trigger a high priority alert.
+  # The lowest value here determines how often the keep-alive checks run,
+  # and thus how often a notification for an unhealthy service will trigger!
+  notify_threshold_seconds:
+    FULL_NODE: 300
+    HARVESTER: 300
+    FARMER: 300
+    WALLET: 300
 
 # Enable this and you'll receive a daily summary notification
 # on your farm performance at the specified time of the day.

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -35,26 +35,20 @@ daily_stats:
   time_of_day: "21:00"
   frequency_hours: 24
 
-# In this section you can enable and configure the log handlers
+# Remove any service your node isn't running. All are enabled by default.
+# Services listed here are checked for health and will start alerting if missing.
+monitored_services:
+  - FULL_NODE
+  - HARVESTER
+  - FARMER
+  - WALLET
+
+# In this section you can configure log handler details
 handlers:
-  # Checks for new coins received (wallet)
   wallet_added_coin_handler:
-    enable: true
     # Transactions with lower amount mojos will be ignored
     # Use this to avoid notification spam during dust storms
     min_mojos_amount:  5 # default: 0
-  # Checks for skipped signage points (full node)
-  finished_signage_point_handler:
-    enable: true
-  # Checks for new blocks found (full node)
-  block_handler:
-    enable: true
-  # Checks for found partials (farmer)
-  partial_handler:
-    enable: true
-  # Checks harvester activity & health (harvester)
-  harvester_activity_handler:
-    enable: true
 
 
 # We support a lot of notifiers, please check the README for more

--- a/main.py
+++ b/main.py
@@ -62,8 +62,7 @@ def init(config: confuse.core.Configuration):
         exit(0)
 
     # Keep a reference here so we can stop the thread
-    # TODO: read keep-alive thresholds from config
-    keep_alive_monitor = KeepAliveMonitor(config=config["keep_alive_monitor"].get(dict))
+    keep_alive_monitor = KeepAliveMonitor(config=config["keep_alive_monitor"])
 
     # Notify manager is responsible for the lifecycle of all notifiers
     notify_manager = NotifyManager(config=config, keep_alive_monitor=keep_alive_monitor)

--- a/main.py
+++ b/main.py
@@ -62,7 +62,7 @@ def init(config: confuse.core.Configuration):
         exit(0)
 
     # Keep a reference here so we can stop the thread
-    keep_alive_monitor = KeepAliveMonitor(config=config["keep_alive_monitor"])
+    keep_alive_monitor = KeepAliveMonitor(config=config)
 
     # Notify manager is responsible for the lifecycle of all notifiers
     notify_manager = NotifyManager(config=config, keep_alive_monitor=keep_alive_monitor)

--- a/src/chia_log/handlers/__init__.py
+++ b/src/chia_log/handlers/__init__.py
@@ -28,7 +28,7 @@ class LogHandlerInterface(ABC):
         pass
 
     def __init__(self, config: ConfigView):
-        logging.info(f"Initializing handler: {self.config_name()}")
+        logging.debug(f"Initializing handler: {self.config_name()}")
 
     @abstractmethod
     def handle(self, logs: str, stats_manager: Optional[StatsManager] = None) -> List[Event]:

--- a/src/chia_log/handlers/condition_checkers/found_blocks.py
+++ b/src/chia_log/handlers/condition_checkers/found_blocks.py
@@ -12,7 +12,7 @@ class FoundBlocks(BlockConditionChecker):
     """Check if any blocks were found."""
 
     def __init__(self):
-        logging.info("Enabled check for found blocks.")
+        logging.debug("Enabled check for found blocks.")
 
     def check(self, obj: BlockMessage) -> Optional[Event]:
         if obj.blocks_count > 0:

--- a/src/chia_log/handlers/condition_checkers/non_decreasing_plots.py
+++ b/src/chia_log/handlers/condition_checkers/non_decreasing_plots.py
@@ -15,7 +15,7 @@ class NonDecreasingPlots(HarvesterConditionChecker):
     """
 
     def __init__(self):
-        logging.info("Enabled check for non-decreasing total plot count.")
+        logging.debug("Enabled check for non-decreasing total plot count.")
         self._max_farmed_plots = 0
         # When copying plots it's common that plots decrease by 1 temporarily
         # by setting the default threshold to 2, we can avoid false alarms

--- a/src/chia_log/handlers/condition_checkers/non_skipped_signage_points.py
+++ b/src/chia_log/handlers/condition_checkers/non_skipped_signage_points.py
@@ -17,7 +17,7 @@ class NonSkippedSignagePoints(FinishedSignageConditionChecker):
     """
 
     def __init__(self):
-        logging.info("Enabled check for finished signage points.")
+        logging.debug("Enabled check for finished signage points.")
         self._last_signage_point_timestamp: datetime = datetime.fromtimestamp(0)
         self._last_signage_point: int = 0
 

--- a/src/chia_log/handlers/condition_checkers/quick_plot_search_time.py
+++ b/src/chia_log/handlers/condition_checkers/quick_plot_search_time.py
@@ -15,7 +15,7 @@ class QuickPlotSearchTime(HarvesterConditionChecker):
     """
 
     def __init__(self):
-        logging.info("Enabled check for time taken to respond to challenges.")
+        logging.debug("Enabled check for time taken to respond to challenges.")
         self._warning_threshold = 20  # seconds
 
     def check(self, obj: HarvesterActivityMessage) -> Optional[Event]:

--- a/src/chia_log/handlers/condition_checkers/time_since_last_farm_event.py
+++ b/src/chia_log/handlers/condition_checkers/time_since_last_farm_event.py
@@ -19,7 +19,7 @@ class TimeSinceLastFarmEvent(HarvesterConditionChecker):
     """
 
     def __init__(self):
-        logging.info("Enabled check for farming events.")
+        logging.debug("Enabled check for farming events.")
         self._info_threshold = 30
         self._warning_threshold = 90
         self._last_timestamp = None

--- a/src/chia_log/log_handler.py
+++ b/src/chia_log/log_handler.py
@@ -51,10 +51,11 @@ class LogHandler(LogConsumerSubscriber):
         self._active_handlers = []
         for service, service_handlers in self.services.items():
             if service.name in config["monitored_services"].get(list):
+                logging.info(f"Enabled service monitoring: {service.name}")
                 for handler in service_handlers:
                     self._active_handlers.append(handler(config["handlers"][handler.config_name()]))
             else:
-                logging.info(f"Disabled service monitoring: {service.name}")
+                logging.debug(f"Disabled service monitoring: {service.name}")
         log_consumer.subscribe(self)
 
     def consume_logs(self, logs: str):

--- a/src/chia_log/log_handler.py
+++ b/src/chia_log/log_handler.py
@@ -49,16 +49,12 @@ class LogHandler(LogConsumerSubscriber):
         self._stats_manager = stats_manager
 
         self._active_handlers = []
-        self._active_services = []
         for service, service_handlers in self.services.items():
             if service.name in config["monitored_services"].get(list):
-                self._active_services.append(service)
                 for handler in service_handlers:
                     self._active_handlers.append(handler(config["handlers"][handler.config_name()]))
             else:
                 logging.info(f"Disabled service monitoring: {service.name}")
-        # Init the keepalive monitor with enabled services
-        notify_manager._keep_alive_monitor.set_services(self._active_services)
         log_consumer.subscribe(self)
 
     def consume_logs(self, logs: str):

--- a/src/chia_log/log_handler.py
+++ b/src/chia_log/log_handler.py
@@ -1,10 +1,9 @@
 # std
-from typing import Optional, List, Type
+from typing import Optional, List, Type, Dict
 import logging
 
 # lib
 from confuse import ConfigView
-from confuse.exceptions import ConfigTypeError
 
 # project
 from src.chia_log.handlers import LogHandlerInterface
@@ -15,16 +14,8 @@ from src.chia_log.handlers.block_handler import BlockHandler
 from src.chia_log.handlers.finished_signage_point_handler import FinishedSignagePointHandler
 from src.chia_log.handlers.wallet_added_coin_handler import WalletAddedCoinHandler
 from src.chia_log.log_consumer import LogConsumerSubscriber, LogConsumer
+from src.notifier import EventService
 from src.notifier.notify_manager import NotifyManager
-
-
-def _check_handler_enabled(config: dict, handler_name: str) -> bool:
-    """Fallback to True for backwards compatability"""
-    try:
-        return config["handlers"][handler_name]["enable"].get(bool)
-    except ConfigTypeError as e:
-        logging.error(f"Invalid config.yaml, enabling handler anyway: {e}")
-    return True
 
 
 class LogHandler(LogConsumerSubscriber):
@@ -48,26 +39,29 @@ class LogHandler(LogConsumerSubscriber):
         notify_manager: NotifyManager,
         stats_manager: Optional[StatsManager] = None,
     ):
+        self.services: Dict[EventService, List[Type[LogHandlerInterface]]] = {
+            EventService.HARVESTER: [HarvesterActivityHandler],
+            EventService.WALLET: [WalletAddedCoinHandler],
+            EventService.FULL_NODE: [BlockHandler, FinishedSignagePointHandler],
+            EventService.FARMER: [PartialHandler],
+        }
         self._notify_manager = notify_manager
         self._stats_manager = stats_manager
 
-        available_handlers: List[Type[LogHandlerInterface]] = [
-            HarvesterActivityHandler,
-            PartialHandler,
-            BlockHandler,
-            FinishedSignagePointHandler,
-            WalletAddedCoinHandler,
-        ]
-        self._handlers = []
-        for handler in available_handlers:
-            if _check_handler_enabled(config, handler.config_name()):
-                self._handlers.append(handler(config["handlers"][handler.config_name()]))
+        self._active_handlers = []
+        self._active_services = []
+        for service, service_handlers in self.services.items():
+            if service.name in config["monitored_services"].get(list):
+                self._active_services.append(service)
+                for handler in service_handlers:
+                    self._active_handlers.append(handler(config["handlers"][handler.config_name()]))
             else:
-                logging.info(f"Disabled handler: {handler.config_name()}")
-
+                logging.info(f"Disabled service monitoring: {service.name}")
+        # Init the keepalive monitor with enabled services
+        notify_manager._keep_alive_monitor.set_services(self._active_services)
         log_consumer.subscribe(self)
 
     def consume_logs(self, logs: str):
-        for handler in self._handlers:
+        for handler in self._active_handlers:
             events = handler.handle(logs, self._stats_manager)
             self._notify_manager.process_events(events)

--- a/src/chia_log/parsers/block_parser.py
+++ b/src/chia_log/parsers/block_parser.py
@@ -25,7 +25,7 @@ class BlockParser:
     """
 
     def __init__(self):
-        logging.info("Enabled parser for block found stats.")
+        logging.debug("Enabled parser for block found stats.")
         self._regex = re.compile(
             r"([0-9:.]*) full_node (?:src|chia).full_node.full_node\s*: INFO\s* ((?:🍀 ️|.)\s*Farmed unfinished_block)"
         )

--- a/src/chia_log/parsers/finished_signage_point_parser.py
+++ b/src/chia_log/parsers/finished_signage_point_parser.py
@@ -25,7 +25,7 @@ class FinishedSignagePointParser:
     """
 
     def __init__(self):
-        logging.info("Enabled parser for finished signage points.")
+        logging.debug("Enabled parser for finished signage points.")
         # Doing some "smart" tricks with this expression to also match the 64th signage point
         # with the same regex expression. See test examples to see how they differ.
         self._regex = re.compile(

--- a/src/chia_log/parsers/harvester_activity_parser.py
+++ b/src/chia_log/parsers/harvester_activity_parser.py
@@ -29,7 +29,7 @@ class HarvesterActivityParser:
     """
 
     def __init__(self):
-        logging.info("Enabled parser for harvester activity - eligible plot events.")
+        logging.debug("Enabled parser for harvester activity - eligible plot events.")
         self._regex = re.compile(
             r"([0-9:.]*) harvester (?:src|chia).harvester.harvester(?:\s?): INFO\s*([0-9]+) plots were "
             r"eligible for farming ([0-9a-z.]*) Found ([0-9]) proofs. Time: ([0-9.]*) s. "

--- a/src/chia_log/parsers/partial_parser.py
+++ b/src/chia_log/parsers/partial_parser.py
@@ -25,7 +25,7 @@ class PartialParser:
     """
 
     def __init__(self):
-        logging.info("Enabled parser for partial submitting stats.")
+        logging.debug("Enabled parser for partial submitting stats.")
         self._regex = re.compile(r"([0-9:.]*) farmer (?:src|chia).farmer.farmer\s*: INFO\s* (Submitting partial)")
 
     def parse(self, logs: str) -> List[PartialMessage]:

--- a/src/chia_log/parsers/wallet_added_coin_parser.py
+++ b/src/chia_log/parsers/wallet_added_coin_parser.py
@@ -23,7 +23,7 @@ class WalletAddedCoinParser:
     """
 
     def __init__(self):
-        logging.info("Enabled parser for wallet activity - added coins.")
+        logging.debug("Enabled parser for wallet activity - added coins.")
         self._regex = re.compile(
             r"([0-9:.]*) wallet (?:src|chia).wallet.wallet_(?:state_manager|node)(?:\s*)?: "
             r"INFO\s*(?:Adding|Adding record to state manager|request) coin: (?:.*)'?amount'?: ([0-9]*)(\s})?,"

--- a/src/default_config.yaml
+++ b/src/default_config.yaml
@@ -18,28 +18,34 @@ chia_logs:
     remote_user: "chia"
     remote_port: 22
 
+# All services and thus handlers are enabled by default
+monitored_services:
+  - FULL_NODE
+  - HARVESTER
+  - FARMER
+  - WALLET
+
 keep_alive_monitor:
   enable_remote_ping: false
   ping_url: null
+  notify_threshold_seconds:
+    FULL_NODE: 300
+    HARVESTER: 300
+    FARMER: 300
+    WALLET: 300
+
 
 daily_stats:
   enable: false
   time_of_day: "21:00"
   frequency_hours: 24
 
-# All handlers are enabled by default
+# Only handlers that have config options are defined here.
+# The enabled param is deprecated, all are enabled if their
+# service is enabled in monitored_services.
 handlers:
   wallet_added_coin_handler:
-    enable: true
     min_mojos_amount: 0
-  finished_signage_point_handler:
-    enable: true
-  block_handler:
-    enable: true
-  partial_handler:
-    enable: true
-  harvester_activity_handler:
-    enable: true
 
 
 # No notifier or notifier feature is enabled by default

--- a/src/notifier/__init__.py
+++ b/src/notifier/__init__.py
@@ -47,6 +47,15 @@ class EventService(Enum):
     DAILY = 3
     WALLET = 4
 
+    @classmethod
+    def _missing_(cls, value):
+        """Allow init with a string representation of the service"""
+
+        names = [s.name.lower() for s in EventService]
+        if isinstance(value, str) and value.lower() in names:
+            return cls(names.index(value.lower()))
+        return super()._missing_(value)
+
 
 @dataclass
 class Event:

--- a/src/notifier/keep_alive_monitor.py
+++ b/src/notifier/keep_alive_monitor.py
@@ -29,57 +29,31 @@ class KeepAliveMonitor:
 
     def __init__(self, config: ConfigView):
         self._notify_manager = None
-        self.config = config
+        # Outside init we only need the keepalive specific config
+        self.config = config["keep_alive_monitor"]
 
-        # These will be set by set_services() once known
         self._last_keep_alive: Dict[EventService, datetime] = {}
         self._last_keep_alive_threshold_seconds: Dict[EventService, int] = {}
+        # Check period will be inferred from minimum threshold of all services.
+        self._check_period = float("inf")
+        self._is_running = False
+        self._keep_alive_check_thread: Thread = Thread()
+
+        # Enable all monitored_services for keepalive monitoring
+        self._set_services([EventService(service_name) for service_name in config["monitored_services"].get(list)])
+
+        # Start thread
+        self._is_running = True
+        self._keep_alive_check_thread = Thread(target=self.check_last_keep_alive)
+        self._keep_alive_check_thread.start()
 
         self._ping_url = None
         if self.config["enable_remote_ping"].get(bool):
             self._ping_url = self.config["ping_url"].get()
             logging.info(f"Enabled remote pinging to {self._ping_url}")
 
-        # Check period will be inferred from minimum threshold of all services.
-        # Note that this period defines how often high priority notifications
-        # will be re-triggered so < 5 min is not recommended
-        self._check_period = float("inf")
-        # No point in starting anything yet since we have no known services.
-        self._is_running = False
-        self._keep_alive_check_thread: Thread = Thread()
-
     def set_notify_manager(self, notify_manager):
         self._notify_manager = notify_manager
-
-    def set_services(self, services: List[EventService]) -> None:
-        # Reset values to fully overwrite services
-        self._last_keep_alive = {}
-        self._last_keep_alive_threshold_seconds = {}
-        for service in services:
-            # TODO: This check will become obsolete once all services emit keepalive events
-            if service in [EventService.HARVESTER]:
-                threshold = self.config["notify_threshold_seconds"][service.name].get(int)
-                self._last_keep_alive[service] = datetime.now()
-                self._last_keep_alive_threshold_seconds[service] = threshold
-                logging.info(f"Keepalive monitor started for {service.name} with a threshold of {threshold}s")
-            else:
-                logging.debug(f"Keepalive not yet implemented for {service.name}, not enabling it.")
-
-        # Calculate check period from lowest service value
-        for threshold in self._last_keep_alive_threshold_seconds.values():
-            self._check_period = min(threshold, self._check_period)
-
-        logging.info(f"Keep-alive check period: {self._check_period} seconds")
-        if self._check_period < 300:
-            logging.warning(
-                "Check period below 5 minutes might result "
-                "in very frequent high priority notifications "
-                "in case something stops working. Is it intended?"
-            )
-        # Start thread
-        self._is_running = True
-        self._keep_alive_check_thread = Thread(target=self.check_last_keep_alive)
-        self._keep_alive_check_thread.start()
 
     def check_last_keep_alive(self):
         """This function runs in separate thread in the background
@@ -138,6 +112,33 @@ class KeepAliveMonitor:
                 urllib.request.urlopen(self._ping_url, timeout=10)
             except Exception as e:
                 logging.error(f"Failed to ping keep-alive: {e}")
+
+    def _set_services(self, services: List[EventService]) -> None:
+        """Set the services monitored for keepalive and the service check period."""
+        for service in services:
+            logging.debug(f"Enabling {service}")
+            # TODO: This check will become obsolete once all services emit keepalive events
+            if service in [EventService.HARVESTER]:
+                threshold = self.config["notify_threshold_seconds"][service.name].get(int)
+                self._last_keep_alive[service] = datetime.now()
+                self._last_keep_alive_threshold_seconds[service] = threshold
+                logging.info(f"Keepalive monitor started for {service.name} with a threshold of {threshold}s")
+            else:
+                logging.debug(f"Keepalive not yet implemented for {service.name}, not enabling it.")
+
+        # Calculate check period from lowest service value
+        for threshold in self._last_keep_alive_threshold_seconds.values():
+            self._check_period = min(threshold, self._check_period)
+
+        logging.info(f"Keep-alive check period: {self._check_period} seconds")
+        # Note that this period defines how often high priority notifications
+        # will be re-triggered so < 5 min is not recommended
+        if self._check_period < 300:
+            logging.warning(
+                "Check period below 5 minutes might result "
+                "in very frequent high priority notifications "
+                "in case something stops working. Is it intended?"
+            )
 
     def stop(self):
         logging.info("Stopping")

--- a/src/notifier/keep_alive_monitor.py
+++ b/src/notifier/keep_alive_monitor.py
@@ -36,8 +36,6 @@ class KeepAliveMonitor:
         self._last_keep_alive_threshold_seconds: Dict[EventService, int] = {}
         # Check period will be inferred from minimum threshold of all services.
         self._check_period = float("inf")
-        self._is_running = False
-        self._keep_alive_check_thread: Thread = Thread()
 
         # Enable all monitored_services for keepalive monitoring
         self._set_services([EventService(service_name) for service_name in config["monitored_services"].get(list)])

--- a/tests/chia_log/handlers/test_wallet_added_coin_handler.py
+++ b/tests/chia_log/handlers/test_wallet_added_coin_handler.py
@@ -25,7 +25,6 @@ class TestWalledAddedCoinHandler(unittest.TestCase):
         self.config.clear()
 
     def testConfig(self):
-        self.assertEqual(self.handler_config["enable"].get(bool), True)
         self.assertEqual(self.handler_config["min_mojos_amount"].get(int), 0)  # Dependent on default value being 0
 
     def testNominal(self):

--- a/tests/notifier/test_keep_alive_monitor.py
+++ b/tests/notifier/test_keep_alive_monitor.py
@@ -5,6 +5,9 @@ from datetime import datetime
 from time import sleep
 from typing import List
 
+# lib
+import confuse
+
 # project
 from src.notifier import Event, EventService, EventType, EventPriority
 from src.notifier.keep_alive_monitor import KeepAliveMonitor
@@ -24,35 +27,53 @@ class DummyNotifyManager:
 class TestKeepAliveMonitor(unittest.TestCase):
     def setUp(self) -> None:
         self.threshold_seconds = 3
-        self.keep_alive_monitor = KeepAliveMonitor(thresholds={EventService.HARVESTER: self.threshold_seconds})
-        self.keep_alive_event = Event(
-            type=EventType.KEEPALIVE, priority=EventPriority.NORMAL, service=EventService.HARVESTER, message=""
+        self.config = confuse.Configuration("chiadog", __name__)
+        self.config.set(
+            {
+                "enable_remote_ping": False,
+                "ping_url": None,
+                "notify_threshold_seconds": {
+                    "HARVESTER": self.threshold_seconds,
+                },
+            }
         )
+        self.keep_alive_monitor = KeepAliveMonitor(self.config)
+
+        # Services that support keepalives
+        self.services = [
+            EventService.HARVESTER,
+        ]
+        # And their events
+        self.keep_alive_events = [
+            Event(type=EventType.KEEPALIVE, priority=EventPriority.NORMAL, service=EventService.HARVESTER, message=""),
+        ]
 
     def tearDown(self) -> None:
         self.keep_alive_monitor.stop()
+        self.config.clear()
 
     def testBasic(self):
         received_high_priority_event = False
 
         def callback(events: List[Event]):
             nonlocal received_high_priority_event
-            self.assertEqual(len(events), 1, "Unexpected number of events")
+            self.assertEqual(len(events), len(self.services), "Unexpected number of events")
             self.assertEqual(events[0].type, EventType.USER, "Unexpected event type")
             self.assertEqual(events[0].priority, EventPriority.HIGH, "Unexpected event priority")
             received_high_priority_event = True
 
         notify_manager = DummyNotifyManager(callback)
         self.keep_alive_monitor.set_notify_manager(notify_manager)
+        self.keep_alive_monitor.set_services(self.services)
 
         begin_tp = datetime.now()
 
         for _ in range(self.threshold_seconds):
-            self.keep_alive_monitor.process_events([self.keep_alive_event])
+            self.keep_alive_monitor.process_events(self.keep_alive_events)
             sleep(1)
 
         while not received_high_priority_event:
-            logging.info("Waiting for high priority event..")
+            logging.info(f"Waiting for high priority event, this should only take {self.threshold_seconds}s")
             sleep(1)
 
         end_tp = datetime.now()


### PR DESCRIPTION
This PR deprecates enabling or disabling individual handlers in favor of service level enablement, which in turn enables all handlers defined for that service.

More ground work for fixing #361. At this PR it's already possible to disable harvester monitoring but there are no other keepalives available yet. The next PR in the chain adds a new keepalive for the wallet as an example.

I'm torn on which services should be monitored by default. The conservative default would be no services, but that clashes with the previous default of running all handlers and the harvester keepalive. So I've opted to default to monitoring all services and thus all handlers, which also enables the harvester keepalive. Where it gets a bit wonky then is when we bring in a wallet keepalive. There's been no harm in having the incoming transaction handler enabled by default, but by comparison the peak handler expects to find a working wallet. If one isn't found, it will start triggering keepalive alerts of no wallet activity.