### PR TITLE
Example of using VCR.py to convert a notifier test to hermetic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,16 +67,17 @@ python3 -m coverage report
 ## Testing remote APIs
 
 To strike a balance between hermetic tests and actually testing against a live API, `VCR.py` is utilized.
-By default tests with prerecorded interactions are tested hermetically. If you instead want to test live or record a new cassette, remove the casette file and run the test with sufficient env variables to produce a valid replacement result.
+By default tests with prerecorded interactions are tested hermetically. If you instead want to test live or record a new cassette, remove the cassette file and run the test with sufficient env variables to produce a valid replacement result.
 
 For example:
 ```
-rm tests/cassette/keep_alive_monitor_remote_ping.yaml
+rm tests/cassette/keep_alive_monitor/*
 REMOTE_PING_URL=https://hc-ping.com/<your-token> python3 -m unittest tests.notifier.test_keep_alive_monitor
 ```
 
 > **Warning**
 > Before committing a cassette file make sure you've sanitized it of your own tokens!
+> Normally this is done at the VCR config level, see: [VCR.py: Filter sensitive data from the request](https://vcrpy.readthedocs.io/en/latest/advanced.html#filter-sensitive-data-from-the-request)
 
 ## Have fun
 

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -11,9 +11,10 @@ enable more than one at the same time - please refer to the [config-example.yaml
 from the Pushover app to overwrite any Silence or Do-Not-Disturb modes on your phone and sound a loud alarm at any time
 of the day to make you aware of any issues in a timely manner.
 
-Test with:
+To test live:
 
 ```
+rm tests/cassette/pushover_notifier/*
 PUSHOVER_API_TOKEN=<api_token> PUSHOVER_USER_KEY=<user_key> python3 -m unittest tests.notifier.test_pushover_notifier
 ```
 

--- a/tests/cassette/keep_alive_monitor/testBasic
+++ b/tests/cassette/keep_alive_monitor/testBasic
@@ -9,7 +9,7 @@ interactions:
       User-Agent:
       - Python-urllib/3.7
     method: GET
-    uri: https://hc-ping.com/mock
+    uri: https://hc-ping.com/
   response:
     body:
       string: OK
@@ -23,7 +23,7 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Sat, 18 Feb 2023 13:52:23 GMT
+      - Sat, 18 Feb 2023 21:24:57 GMT
       ping-body-limit:
       - '100000'
       server:
@@ -41,7 +41,7 @@ interactions:
       User-Agent:
       - Python-urllib/3.7
     method: GET
-    uri: https://hc-ping.com/mock
+    uri: https://hc-ping.com/
   response:
     body:
       string: OK
@@ -55,7 +55,7 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Sat, 18 Feb 2023 13:52:26 GMT
+      - Sat, 18 Feb 2023 21:25:00 GMT
       ping-body-limit:
       - '100000'
       server:

--- a/tests/cassette/pushover_notifier/testHighPriorityNotifications
+++ b/tests/cassette/pushover_notifier/testHighPriorityNotifications
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: title=%F0%9F%9A%A8+Test+HARVESTER&message=High+priority+notification+1.&priority=1
+    headers:
+      Content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://api.pushover.net/1/messages.json
+  response:
+    body:
+      string: '{"status":1,"request":"f4900786-cf2e-4808-b057-f8a9402cbfdb"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - X-Requested-With, X-Prototype-Version, Origin, Accept, Content-Type, X-CSRF-Token,
+        X-Pushover-App, Authorization
+      Access-Control-Allow-Methods:
+      - POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 18 Feb 2023 20:44:19 GMT
+      ETag:
+      - W/"51c1f42c7dc6f3e656ad9c6228cebd1a"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      - DENY
+      X-Limit-App-Limit:
+      - '10000'
+      X-Limit-App-Remaining:
+      - '8986'
+      X-Limit-App-Reset:
+      - '1677650400'
+      X-PO-H:
+      - t
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - f4900786-cf2e-4808-b057-f8a9402cbfdb
+      X-Runtime:
+      - '0.055991'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassette/pushover_notifier/testLowPriorityNotifications
+++ b/tests/cassette/pushover_notifier/testLowPriorityNotifications
@@ -1,0 +1,130 @@
+interactions:
+- request:
+    body: title=%E2%84%B9%EF%B8%8F+Test+HARVESTER&message=Low+priority+notification+1.&priority=-1
+    headers:
+      Content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://api.pushover.net/1/messages.json
+  response:
+    body:
+      string: '{"status":1,"request":"618bd91b-1c56-4bfa-9d9d-188acc2f34e5"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - X-Requested-With, X-Prototype-Version, Origin, Accept, Content-Type, X-CSRF-Token,
+        X-Pushover-App, Authorization
+      Access-Control-Allow-Methods:
+      - POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 18 Feb 2023 20:44:20 GMT
+      ETag:
+      - W/"5f80bbf152b697e7fd3e26c559b173e7"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      - DENY
+      X-Limit-App-Limit:
+      - '10000'
+      X-Limit-App-Remaining:
+      - '8985'
+      X-Limit-App-Reset:
+      - '1677650400'
+      X-PO-H:
+      - t
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 618bd91b-1c56-4bfa-9d9d-188acc2f34e5
+      X-Runtime:
+      - '0.056286'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: title=%E2%84%B9%EF%B8%8F+Test+HARVESTER&message=Low+priority+notification+2.&priority=-1
+    headers:
+      Content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://api.pushover.net/1/messages.json
+  response:
+    body:
+      string: '{"status":1,"request":"5ed13e14-2771-4415-8b29-1f5e3ee024f2"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - X-Requested-With, X-Prototype-Version, Origin, Accept, Content-Type, X-CSRF-Token,
+        X-Pushover-App, Authorization
+      Access-Control-Allow-Methods:
+      - POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 18 Feb 2023 20:44:21 GMT
+      ETag:
+      - W/"d94f819da81887a706cb2e188f9ca977"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      - DENY
+      X-Limit-App-Limit:
+      - '10000'
+      X-Limit-App-Remaining:
+      - '8984'
+      X-Limit-App-Reset:
+      - '1677650400'
+      X-PO-H:
+      - t
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 5ed13e14-2771-4415-8b29-1f5e3ee024f2
+      X-Runtime:
+      - '0.054804'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassette/pushover_notifier/testNormalPriorityNotifications
+++ b/tests/cassette/pushover_notifier/testNormalPriorityNotifications
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: title=%E2%9A%A0%EF%B8%8F+Test+HARVESTER&message=Normal+priority+notification+1.&priority=0
+    headers:
+      Content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://api.pushover.net/1/messages.json
+  response:
+    body:
+      string: '{"status":1,"request":"c19b0ce8-8fa9-4d21-aeb0-44871685bb6a"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - X-Requested-With, X-Prototype-Version, Origin, Accept, Content-Type, X-CSRF-Token,
+        X-Pushover-App, Authorization
+      Access-Control-Allow-Methods:
+      - POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 18 Feb 2023 20:44:21 GMT
+      ETag:
+      - W/"c68f9c5b1b2f49ea05f6c1c4fe1d4b16"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      - DENY
+      X-Limit-App-Limit:
+      - '10000'
+      X-Limit-App-Remaining:
+      - '8983'
+      X-Limit-App-Reset:
+      - '1677650400'
+      X-PO-H:
+      - t
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - c19b0ce8-8fa9-4d21-aeb0-44871685bb6a
+      X-Runtime:
+      - '0.056479'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassette/pushover_notifier/testShowcaseBadNotifications
+++ b/tests/cassette/pushover_notifier/testShowcaseBadNotifications
@@ -1,0 +1,194 @@
+interactions:
+- request:
+    body: title=%F0%9F%9A%A8+Harvester+1+HARVESTER&message=Disconnected+HDD%3F+The+total+plot+count+decreased+from+101+to+42.&priority=1
+    headers:
+      Content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://api.pushover.net/1/messages.json
+  response:
+    body:
+      string: '{"status":1,"request":"6f0d06a3-1ed6-4362-bca8-1898dfb5197a"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - X-Requested-With, X-Prototype-Version, Origin, Accept, Content-Type, X-CSRF-Token,
+        X-Pushover-App, Authorization
+      Access-Control-Allow-Methods:
+      - POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 18 Feb 2023 20:44:22 GMT
+      ETag:
+      - W/"d35723ddfb7db0d378a732b459a093e2"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      - DENY
+      X-Limit-App-Limit:
+      - '10000'
+      X-Limit-App-Remaining:
+      - '8982'
+      X-Limit-App-Reset:
+      - '1677650400'
+      X-PO-H:
+      - t
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 6f0d06a3-1ed6-4362-bca8-1898dfb5197a
+      X-Runtime:
+      - '0.058126'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: title=%F0%9F%9A%A8+Harvester+2+HARVESTER&message=Connected+HDD%3F+The+total+plot+count+increased+from+0+to+42.&priority=1
+    headers:
+      Content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://api.pushover.net/1/messages.json
+  response:
+    body:
+      string: '{"status":1,"request":"7f5cfa6d-8715-45af-b025-d0eac599acb1"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - X-Requested-With, X-Prototype-Version, Origin, Accept, Content-Type, X-CSRF-Token,
+        X-Pushover-App, Authorization
+      Access-Control-Allow-Methods:
+      - POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 18 Feb 2023 20:44:22 GMT
+      ETag:
+      - W/"1fa0013d91125836bc3b4e55d5ae0c62"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      - DENY
+      X-Limit-App-Limit:
+      - '10000'
+      X-Limit-App-Remaining:
+      - '8981'
+      X-Limit-App-Reset:
+      - '1677650400'
+      X-PO-H:
+      - t
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 7f5cfa6d-8715-45af-b025-d0eac599acb1
+      X-Runtime:
+      - '0.061070'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: title=%F0%9F%9A%A8+Harvester+3+HARVESTER&message=Your+harvester+appears+to+be+offline%21+No+events+for+the+past+712+seconds.&priority=1
+    headers:
+      Content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://api.pushover.net/1/messages.json
+  response:
+    body:
+      string: '{"status":1,"request":"cc64177f-d880-47d5-b3c5-29a1c0b78bb7"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - X-Requested-With, X-Prototype-Version, Origin, Accept, Content-Type, X-CSRF-Token,
+        X-Pushover-App, Authorization
+      Access-Control-Allow-Methods:
+      - POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 18 Feb 2023 20:44:23 GMT
+      ETag:
+      - W/"828f55f3a008c267938b8b5ddfc26669"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      - DENY
+      X-Limit-App-Limit:
+      - '10000'
+      X-Limit-App-Remaining:
+      - '8980'
+      X-Limit-App-Reset:
+      - '1677650400'
+      X-PO-H:
+      - t
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - cc64177f-d880-47d5-b3c5-29a1c0b78bb7
+      X-Runtime:
+      - '0.061703'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassette/pushover_notifier/testShowcaseGoodNotifications
+++ b/tests/cassette/pushover_notifier/testShowcaseGoodNotifications
@@ -1,0 +1,194 @@
+interactions:
+- request:
+    body: title=%E2%84%B9%EF%B8%8F+Harvester+1+HARVESTER&message=Found+1+proof%28s%29%21&priority=-1
+    headers:
+      Content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://api.pushover.net/1/messages.json
+  response:
+    body:
+      string: '{"status":1,"request":"35a47654-6aed-4c11-a775-07d2fd95a109"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - X-Requested-With, X-Prototype-Version, Origin, Accept, Content-Type, X-CSRF-Token,
+        X-Pushover-App, Authorization
+      Access-Control-Allow-Methods:
+      - POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 18 Feb 2023 20:44:23 GMT
+      ETag:
+      - W/"c3785e997e61488f5792d15fa17da48c"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      - DENY
+      X-Limit-App-Limit:
+      - '10000'
+      X-Limit-App-Remaining:
+      - '8979'
+      X-Limit-App-Reset:
+      - '1677650400'
+      X-PO-H:
+      - t
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 35a47654-6aed-4c11-a775-07d2fd95a109
+      X-Runtime:
+      - '0.054155'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: title=%E2%84%B9%EF%B8%8F+Harvester+2+HARVESTER&message=Found+1+proof%28s%29%21&priority=-1
+    headers:
+      Content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://api.pushover.net/1/messages.json
+  response:
+    body:
+      string: '{"status":1,"request":"9701d8b0-7006-4323-93ba-34e09cb7138b"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - X-Requested-With, X-Prototype-Version, Origin, Accept, Content-Type, X-CSRF-Token,
+        X-Pushover-App, Authorization
+      Access-Control-Allow-Methods:
+      - POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 18 Feb 2023 20:44:24 GMT
+      ETag:
+      - W/"ac4934336cfc85b82587618ae9c32aa0"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      - DENY
+      X-Limit-App-Limit:
+      - '10000'
+      X-Limit-App-Remaining:
+      - '8978'
+      X-Limit-App-Reset:
+      - '1677650400'
+      X-PO-H:
+      - t
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 9701d8b0-7006-4323-93ba-34e09cb7138b
+      X-Runtime:
+      - '0.055822'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: title=%E2%84%B9%EF%B8%8F+Harvester+3+HARVESTER&message=Found+1+proof%28s%29%21&priority=-1
+    headers:
+      Content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://api.pushover.net/1/messages.json
+  response:
+    body:
+      string: '{"status":1,"request":"d8b1afc8-fef4-40b3-ad80-0b5b0e00b103"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - X-Requested-With, X-Prototype-Version, Origin, Accept, Content-Type, X-CSRF-Token,
+        X-Pushover-App, Authorization
+      Access-Control-Allow-Methods:
+      - POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 18 Feb 2023 20:44:24 GMT
+      ETag:
+      - W/"4557a64655376c19524c87040c61c7aa"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      - DENY
+      X-Limit-App-Limit:
+      - '10000'
+      X-Limit-App-Remaining:
+      - '8977'
+      X-Limit-App-Reset:
+      - '1677650400'
+      X-PO-H:
+      - t
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - d8b1afc8-fef4-40b3-ad80-0b5b0e00b103
+      X-Runtime:
+      - '0.053221'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/notifier/test_keep_alive_monitor.py
+++ b/tests/notifier/test_keep_alive_monitor.py
@@ -17,17 +17,20 @@ from src.notifier.keep_alive_monitor import KeepAliveMonitor
 
 logging.basicConfig(level=logging.DEBUG)
 
+
 def sanitize_ping_url(request):
     # Ping services tend to have path based tokens, so drop the path
-    request.uri = urlsplit(request.uri)._replace(path='/').geturl()
+    request.uri = urlsplit(request.uri)._replace(path="/").geturl()
     return request
 
+
 v = vcr.VCR(
-    cassette_library_dir='tests/cassette/keep_alive_monitor',
-    record_mode='once',
-    match_on=['method', 'host'],
+    cassette_library_dir="tests/cassette/keep_alive_monitor",
+    record_mode="once",
+    match_on=["method", "host"],
     before_record_request=sanitize_ping_url,
 )
+
 
 class DummyNotifyManager:
     def __init__(self, callback):
@@ -83,7 +86,7 @@ class TestKeepAliveMonitor(unittest.TestCase):
 
         begin_tp = datetime.now()
 
-        with v.use_cassette('testBasic') as cass:
+        with v.use_cassette("testBasic") as cass:
             for _ in range(self.threshold_seconds):
                 self.keep_alive_monitor.process_events(self.keep_alive_events)
                 sleep(1)

--- a/tests/notifier/test_pushover_notifier.py
+++ b/tests/notifier/test_pushover_notifier.py
@@ -4,19 +4,24 @@ import unittest
 
 # lib
 import confuse
+import vcr
 
 # project
 from src.notifier import Event, EventType, EventPriority, EventService
 from src.notifier.pushover_notifier import PushoverNotifier
 from .dummy_events import DummyEvents
 
+v = vcr.VCR(
+    cassette_library_dir='tests/cassette/pushover_notifier',
+    record_mode='once',
+    match_on=['method', 'scheme', 'host', 'port', 'path', 'query', 'headers', 'body'],
+    filter_post_data_parameters=['token', 'user']
+)
 
 class TestPushoverNotifier(unittest.TestCase):
     def setUp(self) -> None:
-        self.api_token = os.getenv("PUSHOVER_API_TOKEN")
-        self.user_key = os.getenv("PUSHOVER_USER_KEY")
-        self.assertIsNotNone(self.api_token, "You must export PUSHOVER_API_TOKEN as env variable")
-        self.assertIsNotNone(self.user_key, "You must export PUSHOVER_USER_KEY as env variable")
+        self.api_token = os.getenv("PUSHOVER_API_TOKEN") or "mock"
+        self.user_key = os.getenv("PUSHOVER_USER_KEY") or "mock"
         self.config = confuse.Configuration("chiadog", __name__)
         self.config.set(
             {
@@ -33,23 +38,22 @@ class TestPushoverNotifier(unittest.TestCase):
             config=self.config,
         )
 
-    @unittest.skipUnless(os.getenv("PUSHOVER_API_TOKEN"), "Run only if token available")
+    @v.use_cassette
     def testLowPriorityNotifications(self):
         success = self.notifier.send_events_to_user(events=DummyEvents.get_low_priority_events())
         self.assertTrue(success)
 
-    @unittest.skipUnless(os.getenv("PUSHOVER_API_TOKEN"), "Run only if token available")
+    @v.use_cassette
     def testNormalPriorityNotifications(self):
         success = self.notifier.send_events_to_user(events=DummyEvents.get_normal_priority_events())
         self.assertTrue(success)
 
-    @unittest.skipUnless(os.getenv("PUSHOVER_API_TOKEN"), "Run only if token available")
+    @v.use_cassette
     def testHighPriorityNotifications(self):
         success = self.notifier.send_events_to_user(events=DummyEvents.get_high_priority_events())
         self.assertTrue(success)
 
-    @unittest.skipUnless(os.getenv("PUSHOVER_API_TOKEN"), "Run only if token available")
-    @unittest.skipUnless(os.getenv("SHOWCASE_NOTIFICATIONS"), "Only for showcasing")
+    @v.use_cassette
     def testShowcaseGoodNotifications(self):
         notifiers = [
             PushoverNotifier(
@@ -75,8 +79,7 @@ class TestPushoverNotifier(unittest.TestCase):
             success = notifier.send_events_to_user(events=[found_proof_event])
             self.assertTrue(success)
 
-    @unittest.skipUnless(os.getenv("PUSHOVER_API_TOKEN"), "Run only if token available")
-    @unittest.skipUnless(os.getenv("SHOWCASE_NOTIFICATIONS"), "Only for showcasing")
+    @v.use_cassette
     def testShowcaseBadNotifications(self):
         notifiers = [
             PushoverNotifier(

--- a/tests/notifier/test_pushover_notifier.py
+++ b/tests/notifier/test_pushover_notifier.py
@@ -12,11 +12,12 @@ from src.notifier.pushover_notifier import PushoverNotifier
 from .dummy_events import DummyEvents
 
 v = vcr.VCR(
-    cassette_library_dir='tests/cassette/pushover_notifier',
-    record_mode='once',
-    match_on=['method', 'scheme', 'host', 'port', 'path', 'query', 'headers', 'body'],
-    filter_post_data_parameters=['token', 'user']
+    cassette_library_dir="tests/cassette/pushover_notifier",
+    record_mode="once",
+    match_on=["method", "scheme", "host", "port", "path", "query", "headers", "body"],
+    filter_post_data_parameters=["token", "user"],
 )
+
 
 class TestPushoverNotifier(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
At the same time I tweaked the keep_alive_monitor VCR to be consistent with how I'm proposing the notifier tests would look like.

Hermetic tests bump up coverage significantly and allow more folks to test against previous known behavior of notifiers. For example, if someone did the coversion for the `pushcut` notifier to hermetic, I still could've tested against it, just not live. :-)