### PR TITLE
handle log entries containing version numbers (since chia 2.4.4)

### DIFF
--- a/src/chia_log/parsers/block_parser.py
+++ b/src/chia_log/parsers/block_parser.py
@@ -27,7 +27,7 @@ class BlockParser:
     def __init__(self):
         logging.debug("Enabled parser for block found stats.")
         self._regex = re.compile(
-            r"([0-9:.]*) full_node (?:src|chia).full_node.full_node\s*: INFO\s* ((?:🍀 ️|.)\s*Farmed unfinished_block)"
+            r"([0-9:.]*) (?:[-0-9a-zA-Z.]+ )?full_node (?:src|chia).full_node.full_node\s*: INFO\s* ((?:🍀 ️|.)\s*Farmed unfinished_block)"
         )
 
     def parse(self, logs: str) -> List[BlockMessage]:

--- a/src/chia_log/parsers/finished_signage_point_parser.py
+++ b/src/chia_log/parsers/finished_signage_point_parser.py
@@ -29,7 +29,7 @@ class FinishedSignagePointParser:
         # Doing some "smart" tricks with this expression to also match the 64th signage point
         # with the same regex expression. See test examples to see how they differ.
         self._regex = re.compile(
-            r"([0-9:.]*) full_node (?:src|chia).full_node.full_node(?:\s?): INFO\s*(?:⏲️|.)[a-z A-Z,]* ([0-9]*)\/64"
+            r"([0-9:.]*) (?:[-0-9a-zA-Z.]+ )?full_node (?:src|chia).full_node.full_node(?:\s?): INFO\s*(?:⏲️|.)[a-z A-Z,]* ([0-9]*)\/64"
         )
 
     def parse(self, logs: str) -> List[FinishedSignagePointMessage]:

--- a/src/chia_log/parsers/harvester_activity_parser.py
+++ b/src/chia_log/parsers/harvester_activity_parser.py
@@ -31,7 +31,7 @@ class HarvesterActivityParser:
     def __init__(self):
         logging.debug("Enabled parser for harvester activity - eligible plot events.")
         self._regex = re.compile(
-            r"([0-9:.]*) harvester (?:src|chia).harvester.harvester(?:\s?): INFO\s*([0-9]+) plots were "
+            r"([0-9:.]*) (?:[-0-9a-zA-Z.]+ )?harvester (?:src|chia).harvester.harvester(?:\s?): INFO\s*([0-9]+) plots were "
             r"eligible for farming ([0-9a-z.]*) Found ([0-9]) proofs. Time: ([0-9.]*) s. "
             r"Total ([0-9]*) plots"
         )

--- a/src/chia_log/parsers/partial_parser.py
+++ b/src/chia_log/parsers/partial_parser.py
@@ -26,7 +26,7 @@ class PartialParser:
 
     def __init__(self):
         logging.debug("Enabled parser for partial submitting stats.")
-        self._regex = re.compile(r"([0-9:.]*) farmer (?:src|chia).farmer.farmer\s*: INFO\s* (Submitting partial)")
+        self._regex = re.compile(r"([0-9:.]*) (?:[-0-9a-zA-Z.]+ )?farmer (?:src|chia).farmer.farmer\s*: INFO\s* (Submitting partial)")
 
     def parse(self, logs: str) -> List[PartialMessage]:
         """Parses all farmer activity messages from a bunch of logs

--- a/src/chia_log/parsers/wallet_added_coin_parser.py
+++ b/src/chia_log/parsers/wallet_added_coin_parser.py
@@ -25,7 +25,7 @@ class WalletAddedCoinParser:
     def __init__(self):
         logging.debug("Enabled parser for wallet activity - added coins.")
         self._regex = re.compile(
-            r"([0-9:.]*) wallet (?:src|chia).wallet.wallet_(?:state_manager|node)(?:\s*)?: "
+            r"([0-9:.]*) (?:[-0-9a-zA-Z.]+ )?wallet (?:src|chia).wallet.wallet_(?:state_manager|node)(?:\s*)?: "
             r"INFO\s*(?:Adding|Adding record to state manager|request) coin: (?:.*)'?amount'?: ([0-9]*)(\s})?,"
         )
 

--- a/src/chia_log/parsers/wallet_peak_parser.py
+++ b/src/chia_log/parsers/wallet_peak_parser.py
@@ -28,7 +28,7 @@ class WalletPeakParser:
         logging.debug("Enabled parser for wallet activity - peak age.")
         self._regex = re.compile(
             r"([0-9:.T\-\+]*)"
-            r" wallet (?:src|chia)\.wallet\.wallet_blockchain(?:\s*)?: INFO\s+"
+            r" (?:[-0-9a-zA-Z.]+ )?wallet (?:src|chia)\.wallet\.wallet_blockchain(?:\s*)?: INFO\s+"
             r"Peak set to: ([0-9]+) timestamp: ([0-9]+)"
         )
 


### PR DESCRIPTION
Chia 2.4.4 included a logging format change to insert version numbers prior to the service name.

I've opened https://github.com/Chia-Network/chia-blockchain/issues/18799 (which I don't imagine will be fixed) but also fixed my local chiadog instances.

Here are the fixes which hopefully should work OK with both old and new logging formats - hopefully the regex group is robust enough to handle all possible version strings in future!